### PR TITLE
Add authentication with Azure V2 to api

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -37,6 +37,12 @@ spec:
       memory: 384Mi
   ingresses:
     - "https://isdialogmelding.dev.intern.nav.no"
+  accessPolicy:
+    inbound:
+      rules:
+        - application: fastlegerest
+          namespace: teamsykefravr
+          cluster: dev-fss
   azure:
     application:
       enabled: true
@@ -63,4 +69,3 @@ spec:
       value: Q1_isdialogmelding
     - name: MOTTAK_QUEUE_UTSENDING_QUEUENAME
       value: QA.Q414.IU03_UTSENDING
-

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -37,6 +37,12 @@ spec:
       memory: 384Mi
   ingresses:
     - "https://isdialogmelding.intern.nav.no"
+  accessPolicy:
+    inbound:
+      rules:
+        - application: fastlegerest
+          namespace: teamsykefravr
+          cluster: prod-fss
   azure:
     application:
       enabled: true
@@ -61,4 +67,3 @@ spec:
       value: "P_isdialogmelding"
     - name: MOTTAK_QUEUE_UTSENDING_QUEUENAME
       value: QA.P414.IU03_UTSENDING
-

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -34,6 +34,7 @@ fun main() {
             module {
                 apiModule(
                     applicationState = applicationState,
+                    environment = environment,
                 )
             }
         }

--- a/src/main/kotlin/no/nav/syfo/api/DialogmeldingApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/DialogmeldingApi.kt
@@ -23,7 +23,7 @@ fun Route.registerDialogmeldingApi(
             try {
                 call.respond(HttpStatusCode.OK, "Vellykket!")
             } catch (e: IllegalArgumentException) {
-                val illegalArgumentMessage = "Could not get from oppfolgingsplanApi"
+                val illegalArgumentMessage = "Could not get from dialogmeldingApi"
                 log.warn("$illegalArgumentMessage: {}", e.message)
                 call.respond(HttpStatusCode.BadRequest, e.message ?: illegalArgumentMessage)
             }

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -3,6 +3,8 @@ package no.nav.syfo.application
 import io.ktor.application.*
 
 data class Environment(
+    val aadAppClient: String = getEnvVar("AZURE_APP_CLIENT_ID"),
+    val azureAppWellKnownUrl: String = getEnvVar("AZURE_APP_WELL_KNOWN_URL"),
     val serviceuserUsername: String = getEnvVarAllowNull("SERVICEUSER_USERNAME"),
     val serviceuserPassword: String = getEnvVarAllowNull("SERVICEUSER_PASSWORD"),
     val mqChannelName: String = getEnvVarAllowNull("MQGATEWAY_CHANNEL_NAME", "DEV.APP.SVRCONN"),

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -1,18 +1,29 @@
 package no.nav.syfo.application.api
 
 import io.ktor.application.*
+import io.ktor.auth.*
 import io.ktor.routing.*
 import no.nav.syfo.api.registerDialogmeldingApi
 import no.nav.syfo.application.ApplicationState
-import no.nav.syfo.application.api.authentication.installContentNegotiation
-import no.nav.syfo.application.api.authentication.installStatusPages
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.api.authentication.*
 import no.nav.syfo.oppfolgingsplan.OppfolgingsplanService
 
 fun Application.apiModule(
     applicationState: ApplicationState,
+    environment: Environment,
 ) {
     installContentNegotiation()
     installStatusPages()
+    installJwtAuthentication(
+        jwtIssuerList = listOf(
+            JwtIssuer(
+                acceptedAudienceList = listOf(environment.aadAppClient),
+                jwtIssuerType = JwtIssuerType.AZUREAD_V2,
+                wellKnown = getWellKnown(environment.azureAppWellKnownUrl),
+            ),
+        ),
+    )
 
 //    val mqSender = MQSender(environment)
 
@@ -23,14 +34,11 @@ fun Application.apiModule(
     routing {
         registerPodApi(applicationState)
         registerPrometheusApi()
-        registerDialogmeldingApi(
-            oppfolgingsplanService = oppfolgingsplanService
-        )
 
-//        authenticate(JwtIssuerType.selvbetjening.name) {
-//            registerOppfolgingsplanApi(
-//                oppfolgingsplanService = oppfolgingsplanService,
-//            )
-//        }
+        authenticate(JwtIssuerType.AZUREAD_V2.name) {
+            registerDialogmeldingApi(
+                oppfolgingsplanService = oppfolgingsplanService,
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/application/api/authentication/ApiFeature.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/authentication/ApiFeature.kt
@@ -13,7 +13,6 @@ import no.nav.syfo.util.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URL
-import java.util.*
 import java.util.concurrent.TimeUnit
 
 private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.application.api.authentication")
@@ -40,7 +39,7 @@ fun Authentication.Configuration.configureJwt(
     jwt(name = jwtIssuer.jwtIssuerType.name) {
         verifier(jwkProviderSelvbetjening, jwtIssuer.wellKnown.issuer)
         validate { credential ->
-            if (hasExpectedAudience(credential, jwtIssuer.accectedAudienceList)) {
+            if (hasExpectedAudience(credential, jwtIssuer.acceptedAudienceList)) {
                 JWTPrincipal(credential.payload)
             } else {
                 log.warn(

--- a/src/main/kotlin/no/nav/syfo/application/api/authentication/JwtIssuer.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/authentication/JwtIssuer.kt
@@ -1,12 +1,11 @@
 package no.nav.syfo.application.api.authentication
 
 data class JwtIssuer(
-    val accectedAudienceList: List<String>,
+    val acceptedAudienceList: List<String>,
     val jwtIssuerType: JwtIssuerType,
     val wellKnown: WellKnown
 )
 
 enum class JwtIssuerType {
-    selvbetjening,
-    veileder
+    AZUREAD_V2,
 }


### PR DESCRIPTION
Den skal kunne godta både systemkall og OnBehalfOf-flow, men til å begynne med kommer det kun til komme systemkall fra fastlegerest.
Godta fastlegerest, ved å legge til en identifier til clientId i acceptedAudience. I følge nais doc skal det være ekvivalent med å legge inn selve clientIDen.
"AZURE_APP_WELL_KNOWN_URL" får man tilgang til gjennom azurator, så man trenger ikke eksplisitt sette den i naiserator-filene.