### PR TITLE
Add test for OppfolgingsplanService, verify sent message is correct

### DIFF
--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/OppfolgingsplanServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/OppfolgingsplanServiceSpek.kt
@@ -1,0 +1,34 @@
+package no.nav.syfo.oppfolgingsplan
+
+import io.mockk.*
+import no.nav.syfo.application.mq.MQSender
+import no.nav.syfo.testhelper.generator.defaultFellesformatMessageXmlRegex
+import no.nav.syfo.testhelper.generator.generateRSHodemelding
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import kotlin.test.assertTrue
+
+object OppfolgingsplanServiceSpek : Spek({
+
+    describe("OppfolgingsplanService") {
+        it("Sends correct message on MQ") {
+            val mqSender = mockk<MQSender>()
+            val messageSlot = slot<String>()
+            justRun { mqSender.sendMessageToEmottak(capture(messageSlot)) }
+
+            val oppfolgingsplanService = OppfolgingsplanService(mqSender)
+            val rsHodemelding = generateRSHodemelding()
+
+            oppfolgingsplanService.sendMelding(rsHodemelding)
+
+            verify(exactly = 1) { mqSender.sendMessageToEmottak(any()) }
+
+            val expectedFellesformatMessageAsRegex = defaultFellesformatMessageXmlRegex()
+            val actualFellesformatMessage = messageSlot.captured
+
+            assertTrue(
+                expectedFellesformatMessageAsRegex.matches(actualFellesformatMessage),
+            )
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatMessageXml.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatMessageXml.kt
@@ -1,0 +1,106 @@
+package no.nav.syfo.testhelper.generator
+
+fun defaultFellesformatMessageXmlRegex(): Regex {
+    return Regex(
+        "<\\?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"\\?>\n" +
+            "<EI_fellesformat xmlns=\"http://www.nav.no/xml/eiff/2/\" xmlns:ns6=\"http://www.kith.no/xmlstds/base64container\" xmlns:ns5=\"http://www.kith.no/xmlstds/felleskomponent1\" xmlns:ns2=\"http://www.kith.no/xmlstds/msghead/2006-05-24\" xmlns:ns4=\"http://www.kith.no/xmlstds/dialog/2006-10-11\" xmlns:ns3=\"http://www.w3.org/2000/09/xmldsig#\">\n" +
+            "    <ns2:MsgHead>\n" +
+            "        <ns2:MsgInfo>\n" +
+            "            <ns2:Type V=\"DIALOG_NOTAT\" DN=\"Notat\"/>\n" +
+            "            <ns2:MIGversion>v1.2 2006-05-24</ns2:MIGversion>\n" +
+            "            <ns2:GenDate>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,7}</ns2:GenDate>\n" +
+            "            <ns2:MsgId>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}</ns2:MsgId>\n" +
+            "            <ns2:Ack V=\"J\" DN=\"Ja\"/>\n" +
+            "            <ns2:Sender>\n" +
+            "                <ns2:Organisation>\n" +
+            "                    <ns2:OrganisationName>NAV</ns2:OrganisationName>\n" +
+            "                    <ns2:Ident>\n" +
+            "                        <ns2:Id>889640782</ns2:Id>\n" +
+            "                        <ns2:TypeId V=\"ENH\" S=\"2.16.578.1.12.4.1.1.9051\" DN=\"Organisasjonsnummeret i Enhetsregisteret\"/>\n" +
+            "                    </ns2:Ident>\n" +
+            "                    <ns2:Ident>\n" +
+            "                        <ns2:Id>79768</ns2:Id>\n" +
+            "                        <ns2:TypeId V=\"HER\" S=\"2.16.578.1.12.4.1.1.9051\" DN=\"Identifikator fra Helsetjenesteenhetsregisteret \\(HER-id\\)\"/>\n" +
+            "                    </ns2:Ident>\n" +
+            "                </ns2:Organisation>\n" +
+            "            </ns2:Sender>\n" +
+            "            <ns2:Receiver>\n" +
+            "                <ns2:Organisation>\n" +
+            "                    <ns2:OrganisationName>navn</ns2:OrganisationName>\n" +
+            "                    <ns2:Ident>\n" +
+            "                        <ns2:Id>partnerId</ns2:Id>\n" +
+            "                        <ns2:TypeId V=\"HER\" S=\"2.16.578.1.12.4.1.1.9051\" DN=\"Identifikator fra Helsetjenesteenhetsregisteret \\(HER-id\\)\"/>\n" +
+            "                    </ns2:Ident>\n" +
+            "                    <ns2:Ident>\n" +
+            "                        <ns2:Id>orgnummer</ns2:Id>\n" +
+            "                        <ns2:TypeId V=\"ENH\" S=\"2.16.578.1.12.4.1.1.9051\" DN=\"Organisasjonsnummeret i Enhetsregisteret\"/>\n" +
+            "                    </ns2:Ident>\n" +
+            "                    <ns2:Address>\n" +
+            "                        <ns2:Type V=\"RES\" DN=\"Besøksadresse\"/>\n" +
+            "                        <ns2:StreetAdr>adresse</ns2:StreetAdr>\n" +
+            "                        <ns2:PostalCode>postnummer</ns2:PostalCode>\n" +
+            "                        <ns2:City>poststed</ns2:City>\n" +
+            "                    </ns2:Address>\n" +
+            "                    <ns2:HealthcareProfessional>\n" +
+            "                        <ns2:RoleToPatient V=\"6\" S=\"2.16.578.1.12.4.1.1.9034\" DN=\"Fastlege\"/>\n" +
+            "                        <ns2:FamilyName>Scully</ns2:FamilyName>\n" +
+            "                        <ns2:MiddleName>Katherine</ns2:MiddleName>\n" +
+            "                        <ns2:GivenName>Dana</ns2:GivenName>\n" +
+            "                        <ns2:Ident>\n" +
+            "                            <ns2:Id>fnr</ns2:Id>\n" +
+            "                            <ns2:TypeId V=\"FNR\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"Fødselsnummer Norsk fødselsnummer\"/>\n" +
+            "                        </ns2:Ident>\n" +
+            "                        <ns2:Ident>\n" +
+            "                            <ns2:Id>hprId</ns2:Id>\n" +
+            "                            <ns2:TypeId V=\"HPR\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"HPR-nummer\"/>\n" +
+            "                        </ns2:Ident>\n" +
+            "                    </ns2:HealthcareProfessional>\n" +
+            "                </ns2:Organisation>\n" +
+            "            </ns2:Receiver>\n" +
+            "            <ns2:Patient>\n" +
+            "                <ns2:FamilyName>Innbygger</ns2:FamilyName>\n" +
+            "                <ns2:MiddleName>mellomnavn</ns2:MiddleName>\n" +
+            "                <ns2:GivenName>Idun</ns2:GivenName>\n" +
+            "                <ns2:Ident>\n" +
+            "                    <ns2:Id>innbyggerFnr</ns2:Id>\n" +
+            "                    <ns2:TypeId V=\"FNR\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"Fødselsnummer\"/>\n" +
+            "                </ns2:Ident>\n" +
+            "            </ns2:Patient>\n" +
+            "        </ns2:MsgInfo>\n" +
+            "        <ns2:Document>\n" +
+            "            <ns2:DocumentConnection V=\"H\" DN=\"Hoveddokument\"/>\n" +
+            "            <ns2:RefDoc>\n" +
+            "                <ns2:IssueDate V=\"\\d{4}-\\d{2}-\\d{2}\"/>\n" +
+            "                <ns2:MsgType V=\"XML\" DN=\"XML-instans\"/>\n" +
+            "                <ns2:MimeType>text/xml</ns2:MimeType>\n" +
+            "                <ns2:Content>\n" +
+            "                    <ns4:Dialogmelding>\n" +
+            "                        <ns4:Notat>\n" +
+            "                            <ns4:TemaKodet V=\"1\" S=\"2.16.578.1.12.4.1.1.8127\" DN=\"Oppfølgingsplan\"/>\n" +
+            "                            <ns4:TekstNotatInnhold xsi:type=\"xs:string\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">Åpne PDF-vedlegg</ns4:TekstNotatInnhold>\n" +
+            "                            <ns4:DokIdNotat>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}</ns4:DokIdNotat>\n" +
+            "                            <ns4:RollerRelatertNotat>\n" +
+            "                                <ns4:RolleNotat V=\"1\" S=\"2.16.578.1.12.4.1.1.9057\"/>\n" +
+            "                                <ns4:Person/>\n" +
+            "                            </ns4:RollerRelatertNotat>\n" +
+            "                        </ns4:Notat>\n" +
+            "                    </ns4:Dialogmelding>\n" +
+            "                </ns2:Content>\n" +
+            "            </ns2:RefDoc>\n" +
+            "        </ns2:Document>\n" +
+            "        <ns2:Document>\n" +
+            "            <ns2:DocumentConnection V=\"V\" DN=\"Vedlegg\"/>\n" +
+            "            <ns2:RefDoc>\n" +
+            "                <ns2:IssueDate V=\"\\d{4}-\\d{2}-\\d{2}\"/>\n" +
+            "                <ns2:MsgType V=\"A\" DN=\"Vedlegg\"/>\n" +
+            "                <ns2:MimeType>application/pdf</ns2:MimeType>\n" +
+            "                <ns2:Content>\n" +
+            "                    <ns6:Base64Container>AAECAwQFBgcICQ==</ns6:Base64Container>\n" +
+            "                </ns2:Content>\n" +
+            "            </ns2:RefDoc>\n" +
+            "        </ns2:Document>\n" +
+            "    </ns2:MsgHead>\n" +
+            "    <MottakenhetBlokk partnerReferanse=\"herId\" ebRole=\"Saksbehandler\" ebService=\"Oppfolgingsplan\" ebAction=\"Plan\"/>\n" +
+            "</EI_fellesformat>\n"
+    )
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/RSHodemeldingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/RSHodemeldingGenerator.kt
@@ -1,0 +1,35 @@
+package no.nav.syfo.testhelper.generator
+
+import no.nav.syfo.oppfolgingsplan.domain.*
+
+fun generateRSHodemelding(): RSHodemelding {
+    return RSHodemelding(
+        meldingInfo = RSMeldingInfo(
+            mottaker = RSMottaker(
+                partnerId = "herId",
+                herId = "partnerId",
+                orgnummer = "orgnummer",
+                navn = "navn",
+                adresse = "adresse",
+                postnummer = "postnummer",
+                poststed = "poststed",
+                behandler = RSBehandler(
+                    fnr = "fnr",
+                    hprId = "hprId",
+                    fornavn = "Dana",
+                    mellomnavn = "Katherine",
+                    etternavn = "Scully",
+                )
+            ),
+            pasient = RSPasient(
+                fnr = "innbyggerFnr",
+                fornavn = "Idun",
+                mellomnavn = "mellomnavn",
+                etternavn = "Innbygger",
+            )
+        ),
+        vedlegg = RSVedlegg(
+            vedlegg = byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+        ),
+    )
+}


### PR DESCRIPTION
"Fasit-meldingen" er hentet fra dialogfordeleren, bare endret noen navn, pluss ekstra escapes foran spørsmålstegn og paranteser, for at det skal fungere når man gjør om til Regex.
Grunnen til at man bruker Regex, er for å alltid kunne matche på tid og uuid, som varierer mellom hver kjøring.