### PR TITLE
Lagt til henting og lagring av behandler som kan motta dialogmelding (for aktiv fastlege)

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -60,7 +60,8 @@ fun Application.apiModule(
     )
     val behandlerService = BehandlerService(
         fastlegeClient = fastlegeClient,
-        partnerinfoClient = partnerinfoClient
+        partnerinfoClient = partnerinfoClient,
+        database = database,
     )
     val oppfolgingsplanService = OppfolgingsplanService(
         mqSender = mqSender

--- a/src/main/kotlin/no/nav/syfo/application/database/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/application/database/Database.kt
@@ -5,6 +5,7 @@ import com.zaxxer.hikari.HikariDataSource
 import com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory
 import org.flywaydb.core.Flyway
 import java.sql.Connection
+import java.sql.ResultSet
 
 data class DatabaseConfig(
     val jdbcUrl: String,
@@ -49,4 +50,10 @@ class Database(
 
 interface DatabaseInterface {
     val connection: Connection
+}
+
+fun <T> ResultSet.toList(mapper: ResultSet.() -> T) = mutableListOf<T>().apply {
+    while (next()) {
+        add(mapper())
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
@@ -1,5 +1,12 @@
 package no.nav.syfo.behandler
 
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.behandler.database.createBehandlerDialogmelding
+import no.nav.syfo.behandler.database.createBehandlerDialogmeldingArbeidstaker
+import no.nav.syfo.behandler.database.domain.toBehandler
+import no.nav.syfo.behandler.database.getBehandlerDialogmelding
+import no.nav.syfo.behandler.database.getBehandlerDialogmeldingForArbeidstaker
+import no.nav.syfo.behandler.domain.Behandler
 import no.nav.syfo.behandler.domain.Fastlege
 import no.nav.syfo.behandler.fastlege.FastlegeClient
 import no.nav.syfo.behandler.fastlege.toFastlege
@@ -7,10 +14,32 @@ import no.nav.syfo.behandler.partnerinfo.PartnerinfoClient
 import no.nav.syfo.domain.PersonIdentNumber
 
 class BehandlerService(
-    val fastlegeClient: FastlegeClient,
-    val partnerinfoClient: PartnerinfoClient
+    private val fastlegeClient: FastlegeClient,
+    private val partnerinfoClient: PartnerinfoClient,
+    private val database: DatabaseInterface,
 ) {
-    suspend fun getFastlegeMedPartnerinfo(
+    suspend fun getBehandlere(
+        personIdentNumber: PersonIdentNumber,
+        token: String,
+        callId: String,
+    ): List<Behandler> {
+        val aktivFastlege = getFastlegeMedPartnerinfo(
+            personIdentNumber = personIdentNumber,
+            token = token,
+            callId = callId,
+        )
+
+        return if (aktivFastlege != null) {
+            val behandler = createOrGetBehandler(
+                fastlege = aktivFastlege,
+                personIdentNumber = personIdentNumber,
+            )
+
+            listOf(behandler)
+        } else emptyList()
+    }
+
+    private suspend fun getFastlegeMedPartnerinfo(
         personIdentNumber: PersonIdentNumber,
         token: String,
         callId: String,
@@ -20,17 +49,74 @@ class BehandlerService(
             token = token,
             callId = callId,
         )
-        if (fastlegeResponse?.foreldreEnhetHerId != null) {
-            val partnerinfoResponse = partnerinfoClient.partnerinfo(
-                herId = fastlegeResponse.foreldreEnhetHerId.toString(),
-                token = token,
-                callId = callId,
-            )
-            if (partnerinfoResponse != null) {
-                return fastlegeResponse.toFastlege(partnerinfoResponse.partnerId)
-            }
+
+        if (fastlegeResponse?.foreldreEnhetHerId == null) {
+            return null
         }
 
-        return null
+        val partnerinfoResponse = partnerinfoClient.partnerinfo(
+            herId = fastlegeResponse.foreldreEnhetHerId.toString(),
+            token = token,
+            callId = callId,
+        )
+
+        return if (partnerinfoResponse != null) {
+            fastlegeResponse.toFastlege(partnerinfoResponse.partnerId)
+        } else null
+    }
+
+    private fun createOrGetBehandler(fastlege: Fastlege, personIdentNumber: PersonIdentNumber): Behandler {
+        val pBehandlerForFastlege = database.getBehandlerDialogmelding(partnerId = fastlege.partnerId)
+        if (pBehandlerForFastlege == null) {
+            return createBehandlerDialogmelding(
+                personIdentNumber = personIdentNumber,
+                fastlege = fastlege,
+            )
+        }
+
+        val pBehandlereForArbeidstakerIdList =
+            database.getBehandlerDialogmeldingForArbeidstaker(personIdentNumber = personIdentNumber).map { it.id }
+
+        val isBytteAvFastlege = pBehandlereForArbeidstakerIdList.firstOrNull() != pBehandlerForFastlege.id
+        val behandlerIkkeKnyttetTilArbeidstaker = !pBehandlereForArbeidstakerIdList.contains(pBehandlerForFastlege.id)
+        if (isBytteAvFastlege || behandlerIkkeKnyttetTilArbeidstaker) {
+            addBehandlerDialogmeldingToArbeidstaker(
+                personIdentNumber = personIdentNumber,
+                behandlerDialogmeldingId = pBehandlerForFastlege.id,
+            )
+        }
+
+        return pBehandlerForFastlege.toBehandler()
+    }
+
+    fun createBehandlerDialogmelding(
+        personIdentNumber: PersonIdentNumber,
+        fastlege: Fastlege,
+    ): Behandler {
+        database.connection.use { connection ->
+            val pBehandlerForFastlege = connection.createBehandlerDialogmelding(
+                fastlege = fastlege,
+            )
+            connection.createBehandlerDialogmeldingArbeidstaker(
+                personIdentNumber = personIdentNumber,
+                behandlerDialogmeldingId = pBehandlerForFastlege.id,
+            )
+            connection.commit()
+
+            return pBehandlerForFastlege.toBehandler()
+        }
+    }
+
+    private fun addBehandlerDialogmeldingToArbeidstaker(
+        personIdentNumber: PersonIdentNumber,
+        behandlerDialogmeldingId: Int,
+    ) {
+        database.connection.use { connection ->
+            connection.createBehandlerDialogmeldingArbeidstaker(
+                personIdentNumber = personIdentNumber,
+                behandlerDialogmeldingId = behandlerDialogmeldingId,
+            )
+            connection.commit()
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/behandler/api/BehandlerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/BehandlerApi.kt
@@ -39,13 +39,13 @@ fun Route.registerBehandlerApi(
                     token = token,
                 )
                 if (hasAccess) {
-                    val fastlege = behandlerService.getFastlegeMedPartnerinfo(
+                    val behandlere = behandlerService.getBehandlere(
                         personIdentNumber = personIdentNumber,
                         token = token,
                         callId = callId,
                     )
                     val behandlerDialogmeldingDTOList =
-                        fastlege?.let { listOf(fastlege.toBehandlerDialogmeldingDTO()) } ?: emptyList()
+                        behandlere.map { behandler -> behandler.toBehandlerDialogmeldingDTO() }
                     call.respond(behandlerDialogmeldingDTOList)
                 } else {
                     val accessDeniedMessage = "Denied Veileder access to PersonIdent"

--- a/src/main/kotlin/no/nav/syfo/behandler/api/BehandlerDialogmeldingDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/BehandlerDialogmeldingDTO.kt
@@ -5,7 +5,7 @@ data class BehandlerDialogmeldingDTO(
     val fornavn: String,
     val mellomnavn: String?,
     val etternavn: String,
-    val fnr: String,
+    val fnr: String?,
     val partnerId: String,
     val herId: String,
     val hprId: String?,

--- a/src/main/kotlin/no/nav/syfo/behandler/database/BehandlerDialogmeldingQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/database/BehandlerDialogmeldingQuery.kt
@@ -1,0 +1,179 @@
+package no.nav.syfo.behandler.database
+
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.database.toList
+import no.nav.syfo.behandler.database.domain.PBehandlerDialogmelding
+import no.nav.syfo.behandler.domain.BehandlerType
+import no.nav.syfo.behandler.domain.Fastlege
+import no.nav.syfo.domain.PersonIdentNumber
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.*
+
+const val queryCreateBehandlerDialogmeldingArbeidstaker =
+    """
+        INSERT INTO BEHANDLER_DIALOGMELDING_ARBEIDSTAKER (
+            id,
+            uuid,
+            arbeidstaker_personident,
+            created_at,
+            behandler_dialogmelding_id
+            ) VALUES (DEFAULT, ?, ?, ?, ?) RETURNING id
+    """
+
+fun Connection.createBehandlerDialogmeldingArbeidstaker(
+    personIdentNumber: PersonIdentNumber,
+    behandlerDialogmeldingId: Int,
+) {
+    val uuid = UUID.randomUUID()
+    val idList = this.prepareStatement(queryCreateBehandlerDialogmeldingArbeidstaker).use {
+        it.setString(1, uuid.toString())
+        it.setString(2, personIdentNumber.value)
+        it.setTimestamp(3, Timestamp.from(Instant.now()))
+        it.setInt(4, behandlerDialogmeldingId)
+        it.executeQuery().toList { getInt("id") }
+    }
+
+    if (idList.size != 1) {
+        throw SQLException("Creating BehandlerDialogmeldingArbeidstaker failed, no rows affected.")
+    }
+}
+
+fun Connection.createBehandlerDialogmelding(
+    fastlege: Fastlege,
+): PBehandlerDialogmelding {
+    val behandlerRef = UUID.randomUUID()
+    val now = Timestamp.from(Instant.now())
+    val behandlerDialogmeldingList = this.prepareStatement(queryCreateBehandlerDialogmelding).use {
+        it.setString(1, behandlerRef.toString())
+        it.setString(2, BehandlerType.FASTLEGE.name)
+        it.setString(3, fastlege.fnr?.value)
+        it.setString(4, fastlege.fornavn)
+        it.setString(5, fastlege.mellomnavn)
+        it.setString(6, fastlege.etternavn)
+        it.setString(7, fastlege.partnerId.toString())
+        it.setString(8, fastlege.herId.toString())
+        it.setString(9, fastlege.parentHerId.toString())
+        it.setString(10, fastlege.helsepersonellregisterId)
+        it.setString(11, fastlege.kontor.navn)
+        it.setString(12, fastlege.kontor.postadresse.adresse)
+        it.setString(13, fastlege.kontor.postadresse.postnummer)
+        it.setString(14, fastlege.kontor.postadresse.poststed)
+        it.setString(15, fastlege.kontor.orgnummer?.value)
+        it.setString(16, fastlege.kontor.telefon)
+        it.setTimestamp(17, now)
+        it.setTimestamp(18, now)
+        it.executeQuery().toList { toPBehandlerDialogmelding() }
+    }
+
+    if (behandlerDialogmeldingList.size != 1) {
+        throw SQLException("Creating BehandlerDialogmelding failed, no rows affected.")
+    }
+
+    return behandlerDialogmeldingList.first()
+}
+
+const val queryCreateBehandlerDialogmelding =
+    """
+        INSERT INTO BEHANDLER_DIALOGMELDING (
+            id,
+            behandler_ref,
+            type,
+            personident,
+            fornavn,
+            mellomnavn,
+            etternavn,
+            partner_id,
+            her_id,
+            parent_her_id,
+            hpr_id,
+            kontor,
+            adresse,
+            postnummer,
+            poststed,
+            orgnummer,
+            telefon,
+            created_at,
+            updated_at
+            ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) 
+            RETURNING
+            id,
+            behandler_ref,
+            type,
+            personident,
+            fornavn,
+            mellomnavn,
+            etternavn,
+            partner_id,
+            her_id,
+            parent_her_id,
+            hpr_id,
+            kontor,
+            adresse,
+            postnummer,
+            poststed,
+            orgnummer,
+            telefon,
+            created_at,
+            updated_at
+    """
+
+const val queryGetBehandlerDialogmeldingForPartnerId =
+    """
+        SELECT * FROM BEHANDLER_DIALOGMELDING WHERE partner_id = ?
+    """
+
+fun DatabaseInterface.getBehandlerDialogmelding(partnerId: Int): PBehandlerDialogmelding? {
+    return this.connection.use { connection ->
+        connection.prepareStatement(queryGetBehandlerDialogmeldingForPartnerId)
+            .use {
+                it.setString(1, partnerId.toString())
+                it.executeQuery().toList { toPBehandlerDialogmelding() }
+            }
+    }.firstOrNull()
+}
+
+const val queryGetBehandlerDialogmeldingForArbeidstakerPersonIdent =
+    """
+        SELECT BEHANDLER_DIALOGMELDING.* 
+        FROM BEHANDLER_DIALOGMELDING
+        INNER JOIN BEHANDLER_DIALOGMELDING_ARBEIDSTAKER ON BEHANDLER_DIALOGMELDING_ARBEIDSTAKER.behandler_dialogmelding_id = BEHANDLER_DIALOGMELDING.id
+        AND BEHANDLER_DIALOGMELDING_ARBEIDSTAKER.arbeidstaker_personident = ?
+        ORDER BY BEHANDLER_DIALOGMELDING_ARBEIDSTAKER.created_at DESC
+    """
+
+fun DatabaseInterface.getBehandlerDialogmeldingForArbeidstaker(personIdentNumber: PersonIdentNumber): List<PBehandlerDialogmelding> {
+    return this.connection.use { connection ->
+        connection.prepareStatement(queryGetBehandlerDialogmeldingForArbeidstakerPersonIdent)
+            .use {
+                it.setString(1, personIdentNumber.value)
+                it.executeQuery().toList { toPBehandlerDialogmelding() }
+            }
+    }
+}
+
+fun ResultSet.toPBehandlerDialogmelding(): PBehandlerDialogmelding =
+    PBehandlerDialogmelding(
+        id = getInt("id"),
+        behandlerRef = UUID.fromString(getString("behandler_ref")),
+        type = getString("type"),
+        personident = getString("personident"),
+        fornavn = getString("fornavn"),
+        mellomnavn = getString("mellomnavn"),
+        etternavn = getString("etternavn"),
+        partnerId = getString("partner_id"),
+        herId = getString("her_id"),
+        parentHerId = getString("parent_her_id"),
+        hprId = getString("hpr_id"),
+        kontor = getString("kontor"),
+        adresse = getString("adresse"),
+        postnummer = getString("postnummer"),
+        poststed = getString("poststed"),
+        orgnummer = getString("orgnummer"),
+        telefon = getString("telefon"),
+        createdAt = getTimestamp("created_at").toLocalDateTime(),
+        updatedAt = getTimestamp("updated_at").toLocalDateTime(),
+    )

--- a/src/main/kotlin/no/nav/syfo/behandler/database/domain/PBehandlerDialogmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/database/domain/PBehandlerDialogmelding.kt
@@ -1,0 +1,50 @@
+package no.nav.syfo.behandler.database.domain
+
+import no.nav.syfo.behandler.domain.Behandler
+import no.nav.syfo.behandler.domain.BehandlerType
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Virksomhetsnummer
+import java.time.LocalDateTime
+import java.util.*
+
+data class PBehandlerDialogmelding(
+    val id: Int,
+    val behandlerRef: UUID,
+    val type: String,
+    val personident: String?,
+    val fornavn: String,
+    val mellomnavn: String?,
+    val etternavn: String,
+    val partnerId: String,
+    val herId: String?,
+    val parentHerId: String?,
+    val hprId: String?,
+    val kontor: String?,
+    val adresse: String?,
+    val postnummer: String?,
+    val poststed: String?,
+    val orgnummer: String?,
+    val telefon: String?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+
+fun PBehandlerDialogmelding.toBehandler() = Behandler(
+    id = this.id,
+    behandlerRef = this.behandlerRef,
+    type = BehandlerType.valueOf(this.type),
+    personident = this.personident?.let { PersonIdentNumber(it) },
+    fornavn = this.fornavn,
+    mellomnavn = this.mellomnavn,
+    etternavn = this.etternavn,
+    partnerId = this.partnerId,
+    herId = this.herId,
+    parentHerId = this.parentHerId,
+    hprId = this.hprId,
+    kontor = this.kontor,
+    adresse = this.adresse,
+    postnummer = this.postnummer,
+    poststed = this.poststed,
+    orgnummer = this.orgnummer?.let { Virksomhetsnummer(it) },
+    telefon = this.telefon,
+)

--- a/src/main/kotlin/no/nav/syfo/behandler/domain/Behandler.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/domain/Behandler.kt
@@ -1,0 +1,43 @@
+package no.nav.syfo.behandler.domain
+
+import no.nav.syfo.behandler.api.BehandlerDialogmeldingDTO
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Virksomhetsnummer
+import java.util.*
+
+data class Behandler(
+    val id: Int,
+    val type: BehandlerType,
+    val behandlerRef: UUID,
+    val personident: PersonIdentNumber?,
+    val fornavn: String,
+    val mellomnavn: String?,
+    val etternavn: String,
+    val partnerId: String,
+    val herId: String?,
+    val parentHerId: String?,
+    val hprId: String?,
+    val kontor: String?,
+    val adresse: String?,
+    val postnummer: String?,
+    val poststed: String?,
+    val orgnummer: Virksomhetsnummer?,
+    val telefon: String?,
+)
+
+fun Behandler.toBehandlerDialogmeldingDTO() = BehandlerDialogmeldingDTO(
+    type = this.type.name,
+    fornavn = this.fornavn,
+    mellomnavn = this.mellomnavn,
+    etternavn = this.etternavn,
+    fnr = this.personident?.value,
+    partnerId = this.partnerId,
+    herId = this.herId.toString(),
+    hprId = this.hprId,
+    orgnummer = this.orgnummer?.value,
+    kontor = this.kontor,
+    adresse = this.adresse,
+    postnummer = this.postnummer,
+    poststed = this.poststed,
+    telefon = this.telefon,
+)

--- a/src/main/kotlin/no/nav/syfo/behandler/domain/BehandlerType.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/domain/BehandlerType.kt
@@ -1,5 +1,5 @@
 package no.nav.syfo.behandler.domain
 
 enum class BehandlerType {
-    FASTLEGE
+    FASTLEGE,
 }

--- a/src/main/kotlin/no/nav/syfo/behandler/domain/Fastlege.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/domain/Fastlege.kt
@@ -1,20 +1,22 @@
 package no.nav.syfo.behandler.domain
 
-import no.nav.syfo.behandler.api.BehandlerDialogmeldingDTO
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Virksomhetsnummer
 
 data class Fastlege(
     val fornavn: String,
     val mellomnavn: String?,
     val etternavn: String,
-    val fnr: String,
+    val fnr: PersonIdentNumber?,
     val partnerId: Int,
-    val herId: Int,
+    val herId: Int?,
+    val parentHerId: Int?,
     val helsepersonellregisterId: String?,
     val kontor: Kontor,
 ) {
     data class Kontor(
         val navn: String?,
-        val orgnummer: String?,
+        val orgnummer: Virksomhetsnummer?,
         val postadresse: Adresse,
         val besoeksadresse: Adresse,
         val telefon: String?,
@@ -24,24 +26,5 @@ data class Fastlege(
         val adresse: String?,
         val postnummer: String?,
         val poststed: String?,
-    )
-}
-
-fun Fastlege.toBehandlerDialogmeldingDTO(): BehandlerDialogmeldingDTO {
-    return BehandlerDialogmeldingDTO(
-        type = BehandlerType.FASTLEGE.name,
-        fornavn = this.fornavn,
-        mellomnavn = this.mellomnavn,
-        etternavn = this.etternavn,
-        fnr = this.fnr,
-        partnerId = this.partnerId.toString(),
-        herId = this.herId.toString(),
-        hprId = this.helsepersonellregisterId,
-        orgnummer = this.kontor.orgnummer,
-        kontor = this.kontor.navn,
-        adresse = this.kontor.postadresse.adresse,
-        postnummer = this.kontor.postadresse.postnummer,
-        poststed = this.kontor.postadresse.poststed,
-        telefon = this.kontor.telefon,
     )
 }

--- a/src/main/kotlin/no/nav/syfo/behandler/fastlege/FastlegeResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/fastlege/FastlegeResponse.kt
@@ -1,14 +1,16 @@
 package no.nav.syfo.behandler.fastlege
 
 import no.nav.syfo.behandler.domain.Fastlege
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Virksomhetsnummer
 import java.time.LocalDate
 
 data class FastlegeResponse(
     val fornavn: String,
     val mellomnavn: String?,
     val etternavn: String,
-    val fnr: String,
-    val herId: Int,
+    val fnr: String?,
+    val herId: Int?,
     val foreldreEnhetHerId: Int?,
     val helsepersonellregisterId: String?,
     val pasient: Pasient,
@@ -43,33 +45,30 @@ data class FastlegeResponse(
     )
 }
 
-fun FastlegeResponse.Fastlegekontor.toKontor(): Fastlege.Kontor {
-    return Fastlege.Kontor(
-        navn = this.navn,
-        orgnummer = this.orgnummer,
-        postadresse = Fastlege.Adresse(
-            adresse = this.postadresse?.adresse,
-            postnummer = this.postadresse?.postnummer,
-            poststed = this.postadresse?.poststed,
-        ),
-        besoeksadresse = Fastlege.Adresse(
-            adresse = this.besoeksadresse?.adresse,
-            postnummer = this.besoeksadresse?.postnummer,
-            poststed = this.besoeksadresse?.poststed,
-        ),
-        telefon = this.telefon,
-    )
-}
+fun FastlegeResponse.Fastlegekontor.toKontor() = Fastlege.Kontor(
+    navn = this.navn,
+    orgnummer = this.orgnummer?.let { Virksomhetsnummer(it) },
+    postadresse = Fastlege.Adresse(
+        adresse = this.postadresse?.adresse,
+        postnummer = this.postadresse?.postnummer,
+        poststed = this.postadresse?.poststed,
+    ),
+    besoeksadresse = Fastlege.Adresse(
+        adresse = this.besoeksadresse?.adresse,
+        postnummer = this.besoeksadresse?.postnummer,
+        poststed = this.besoeksadresse?.poststed,
+    ),
+    telefon = this.telefon,
+)
 
-fun FastlegeResponse.toFastlege(partnerId: Int): Fastlege {
-    return Fastlege(
-        fornavn = this.fornavn,
-        mellomnavn = this.mellomnavn,
-        etternavn = this.etternavn,
-        partnerId = partnerId,
-        herId = this.herId,
-        helsepersonellregisterId = this.helsepersonellregisterId,
-        fnr = this.fnr,
-        kontor = this.fastlegekontor.toKontor(),
-    )
-}
+fun FastlegeResponse.toFastlege(partnerId: Int) = Fastlege(
+    fornavn = this.fornavn,
+    mellomnavn = this.mellomnavn,
+    etternavn = this.etternavn,
+    partnerId = partnerId,
+    herId = this.herId,
+    parentHerId = this.foreldreEnhetHerId,
+    helsepersonellregisterId = this.helsepersonellregisterId,
+    fnr = this.fnr?.let { PersonIdentNumber(it) },
+    kontor = this.fastlegekontor.toKontor(),
+)

--- a/src/main/kotlin/no/nav/syfo/domain/Virksomhetsnummer.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Virksomhetsnummer.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.domain
+
+data class Virksomhetsnummer(val value: String) {
+    private val nineDigits = Regex("^\\d{9}\$")
+
+    init {
+        if (!nineDigits.matches(value)) {
+            throw IllegalArgumentException("$value is not a valid Virksomhetsnummer")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/behandler/BehandlerServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandler/BehandlerServiceSpek.kt
@@ -1,0 +1,269 @@
+package no.nav.syfo.behandler
+
+import io.ktor.server.testing.*
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.behandler.database.getBehandlerDialogmeldingForArbeidstaker
+import no.nav.syfo.behandler.fastlege.FastlegeClient
+import no.nav.syfo.behandler.fastlege.FastlegeResponse
+import no.nav.syfo.behandler.fastlege.toFastlege
+import no.nav.syfo.behandler.partnerinfo.PartnerinfoClient
+import no.nav.syfo.behandler.partnerinfo.PartnerinfoResponse
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.testhelper.*
+import no.nav.syfo.testhelper.generator.generateFastlegeResponse
+import no.nav.syfo.testhelper.generator.generatePartnerinfoResponse
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class BehandlerServiceSpek : Spek({
+
+    val anyToken = "token"
+    val anyCallId = "callId"
+    val partnerId = 1
+    val otherPartnerId = 2
+    val parentHerId = 7
+    val otherParentHerId = 8
+
+    fun FastlegeClient.mockResponse(personIdentNumber: PersonIdentNumber, response: FastlegeResponse) {
+        coEvery {
+            this@mockResponse.fastlege(
+                personIdentNumber,
+                anyToken,
+                anyCallId
+            )
+        } returns response
+    }
+
+    fun PartnerinfoClient.mockResponse(parentHerId: Int, response: PartnerinfoResponse) {
+        coEvery {
+            this@mockResponse.partnerinfo(
+                parentHerId.toString(),
+                anyToken,
+                anyCallId
+            )
+        } returns response
+    }
+
+    describe("BehandlerService") {
+        with(TestApplicationEngine()) {
+            start()
+
+            val fastlegeClientMock = mockk<FastlegeClient>()
+            val partnerinfoClientMock = mockk<PartnerinfoClient>()
+            val externalMockEnvironment = ExternalMockEnvironment()
+            val database = externalMockEnvironment.database
+            val behandlerService = BehandlerService(
+                fastlegeClient = fastlegeClientMock,
+                partnerinfoClient = partnerinfoClientMock,
+                database = database
+            )
+
+            beforeGroup {
+                externalMockEnvironment.startExternalMocks()
+            }
+
+            beforeEachTest {
+                clearAllMocks()
+            }
+
+            afterEachTest {
+                database.dropData()
+            }
+
+            afterGroup {
+                externalMockEnvironment.stopExternalMocks()
+            }
+
+            describe("getBehandlere uten behandlere i database") {
+                it("getBehandlere lagrer behandler for arbeidstaker med fastlege") {
+                    fastlegeClientMock.mockResponse(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        generateFastlegeResponse(parentHerId)
+                    )
+                    partnerinfoClientMock.mockResponse(parentHerId, generatePartnerinfoResponse(partnerId))
+
+                    runBlocking {
+                        val behandlere =
+                            behandlerService.getBehandlere(UserConstants.ARBEIDSTAKER_FNR, anyToken, anyCallId)
+                        behandlere.size shouldBeEqualTo 1
+                        behandlere.first().partnerId shouldBeEqualTo partnerId.toString()
+                    }
+
+                    database.getBehandlerDialogmeldingForArbeidstaker(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                    ).size shouldBeEqualTo 1
+                }
+                it("getBehandlere kallt flere ganger lagrer én behandler for arbeidstaker med fastlege") {
+                    fastlegeClientMock.mockResponse(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        generateFastlegeResponse(parentHerId)
+                    )
+                    partnerinfoClientMock.mockResponse(parentHerId, generatePartnerinfoResponse(partnerId))
+
+                    runBlocking {
+                        val behandlere =
+                            behandlerService.getBehandlere(UserConstants.ARBEIDSTAKER_FNR, anyToken, anyCallId)
+                        behandlere.size shouldBeEqualTo 1
+                        behandlere.first().partnerId shouldBeEqualTo partnerId.toString()
+                    }
+
+                    database.getBehandlerDialogmeldingForArbeidstaker(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                    ).size shouldBeEqualTo 1
+
+                    runBlocking {
+                        val behandlere =
+                            behandlerService.getBehandlere(UserConstants.ARBEIDSTAKER_FNR, anyToken, anyCallId)
+                        behandlere.size shouldBeEqualTo 1
+                        behandlere.first().partnerId shouldBeEqualTo partnerId.toString()
+                    }
+
+                    database.getBehandlerDialogmeldingForArbeidstaker(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                    ).size shouldBeEqualTo 1
+                }
+                it("getBehandlere lagrer én behandler for to arbeidstakere med samme fastlege") {
+                    val fastlegeResponse = generateFastlegeResponse(parentHerId)
+                    fastlegeClientMock.mockResponse(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        fastlegeResponse
+                    )
+                    fastlegeClientMock.mockResponse(
+                        UserConstants.ANNEN_ARBEIDSTAKER_FNR,
+                        fastlegeResponse
+                    )
+                    partnerinfoClientMock.mockResponse(parentHerId, generatePartnerinfoResponse(partnerId))
+
+                    runBlocking {
+                        val behandlere =
+                            behandlerService.getBehandlere(UserConstants.ARBEIDSTAKER_FNR, anyToken, anyCallId)
+                        behandlere.size shouldBeEqualTo 1
+                        behandlere.first().partnerId shouldBeEqualTo partnerId.toString()
+                    }
+
+                    val behandlerDialogmeldingForArbeidstakerList = database.getBehandlerDialogmeldingForArbeidstaker(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                    )
+                    behandlerDialogmeldingForArbeidstakerList.size shouldBeEqualTo 1
+
+                    runBlocking {
+                        val behandlere =
+                            behandlerService.getBehandlere(UserConstants.ANNEN_ARBEIDSTAKER_FNR, anyToken, anyCallId)
+                        behandlere.size shouldBeEqualTo 1
+                        behandlere.first().partnerId shouldBeEqualTo partnerId.toString()
+                    }
+
+                    val behandlerDialogmeldingForAnnenArbeidstakerList = database.getBehandlerDialogmeldingForArbeidstaker(
+                        UserConstants.ANNEN_ARBEIDSTAKER_FNR,
+                    )
+                    behandlerDialogmeldingForAnnenArbeidstakerList.size shouldBeEqualTo 1
+                    behandlerDialogmeldingForArbeidstakerList.first() shouldBeEqualTo behandlerDialogmeldingForAnnenArbeidstakerList.first()
+                }
+            }
+            describe("getBehandlere med behandlere i databasen") {
+                it("getBehandlere lagrer ikke ny behandler når fastlege er siste lagret behandler for arbeidstaker") {
+                    val fastlegeResponse = generateFastlegeResponse(parentHerId)
+                    behandlerService.createBehandlerDialogmelding(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        fastlegeResponse.toFastlege(partnerId),
+                    )
+                    fastlegeClientMock.mockResponse(UserConstants.ARBEIDSTAKER_FNR, fastlegeResponse)
+                    partnerinfoClientMock.mockResponse(parentHerId, generatePartnerinfoResponse(partnerId))
+
+                    runBlocking {
+                        val behandlere =
+                            behandlerService.getBehandlere(UserConstants.ARBEIDSTAKER_FNR, anyToken, anyCallId)
+                        behandlere.size shouldBeEqualTo 1
+                        behandlere.first().partnerId shouldBeEqualTo partnerId.toString()
+                    }
+
+                    database.getBehandlerDialogmeldingForArbeidstaker(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                    ).size shouldBeEqualTo 1
+                }
+                it("getBehandlere lagrer ny kobling til behandler for arbeidstaker når samme behandler finnes for annen arbeidstaker") {
+                    val fastlegeResponse = generateFastlegeResponse(parentHerId)
+                    behandlerService.createBehandlerDialogmelding(
+                        UserConstants.ANNEN_ARBEIDSTAKER_FNR,
+                        fastlegeResponse.toFastlege(partnerId),
+                    )
+                    fastlegeClientMock.mockResponse(UserConstants.ARBEIDSTAKER_FNR, fastlegeResponse)
+                    partnerinfoClientMock.mockResponse(parentHerId, generatePartnerinfoResponse(partnerId))
+
+                    runBlocking {
+                        val behandlere =
+                            behandlerService.getBehandlere(UserConstants.ARBEIDSTAKER_FNR, anyToken, anyCallId)
+                        behandlere.size shouldBeEqualTo 1
+                        behandlere.first().partnerId shouldBeEqualTo partnerId.toString()
+                    }
+
+                    database.getBehandlerDialogmeldingForArbeidstaker(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                    ).size shouldBeEqualTo 1
+                }
+                it("getBehandlere lagrer ny behandler for arbeidstaker når fastlege er annen enn siste lagret behandler") {
+                    val behandlerRef = behandlerService.createBehandlerDialogmelding(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        generateFastlegeResponse(otherParentHerId).toFastlege(otherPartnerId),
+                    ).behandlerRef
+                    fastlegeClientMock.mockResponse(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        generateFastlegeResponse(parentHerId),
+                    )
+                    partnerinfoClientMock.mockResponse(parentHerId, generatePartnerinfoResponse(partnerId))
+
+                    runBlocking {
+                        val behandlere =
+                            behandlerService.getBehandlere(UserConstants.ARBEIDSTAKER_FNR, anyToken, anyCallId)
+                        behandlere.size shouldBeEqualTo 1
+                        behandlere.first().partnerId shouldBeEqualTo partnerId.toString()
+                    }
+
+                    val behandlerDialogmeldingForArbeidstakerList = database.getBehandlerDialogmeldingForArbeidstaker(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                    )
+                    behandlerDialogmeldingForArbeidstakerList.size shouldBeEqualTo 2
+                    behandlerDialogmeldingForArbeidstakerList[0].behandlerRef shouldNotBeEqualTo behandlerRef
+                    behandlerDialogmeldingForArbeidstakerList[1].behandlerRef shouldBeEqualTo behandlerRef
+                }
+                it("getBehandlere lagrer ny behandler for arbeidstaker med annen fastlege enn siste lagret behandler og det finnes tidligere lagret behandler lik fastlege") {
+                    val fastlegeResponse = generateFastlegeResponse(parentHerId)
+                    val otherFastlegeResponse = generateFastlegeResponse(otherParentHerId)
+                    val behandlerRef = behandlerService.createBehandlerDialogmelding(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        fastlegeResponse.toFastlege(partnerId),
+                    ).behandlerRef
+                    val otherBehandlerRef = behandlerService.createBehandlerDialogmelding(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        otherFastlegeResponse.toFastlege(otherPartnerId),
+                    ).behandlerRef
+                    fastlegeClientMock.mockResponse(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        fastlegeResponse,
+                    )
+                    partnerinfoClientMock.mockResponse(parentHerId, generatePartnerinfoResponse(partnerId))
+
+                    runBlocking {
+                        val behandlere =
+                            behandlerService.getBehandlere(UserConstants.ARBEIDSTAKER_FNR, anyToken, anyCallId)
+                        behandlere.size shouldBeEqualTo 1
+                        behandlere.first().partnerId shouldBeEqualTo partnerId.toString()
+                    }
+
+                    val behandlerDialogmeldingForArbeidstakerList = database.getBehandlerDialogmeldingForArbeidstaker(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                    )
+                    behandlerDialogmeldingForArbeidstakerList.size shouldBeEqualTo 3
+                    behandlerDialogmeldingForArbeidstakerList[0].behandlerRef shouldBeEqualTo behandlerRef
+                    behandlerDialogmeldingForArbeidstakerList[1].behandlerRef shouldBeEqualTo otherBehandlerRef
+                    behandlerDialogmeldingForArbeidstakerList[2].behandlerRef shouldBeEqualTo behandlerRef
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/behandler/api/BehandlerApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandler/api/BehandlerApiSpek.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.http.*
 import io.ktor.server.testing.*
+import no.nav.syfo.behandler.database.getBehandlerDialogmeldingForArbeidstaker
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
 import no.nav.syfo.testhelper.generator.generateFastlegeResponse
@@ -22,10 +23,15 @@ class BehandlerApiSpek : Spek({
         start()
 
         val externalMockEnvironment = ExternalMockEnvironment()
+        val database = externalMockEnvironment.database
         application.testApiModule(externalMockEnvironment = externalMockEnvironment)
 
         beforeGroup {
             externalMockEnvironment.startExternalMocks()
+        }
+
+        afterEachTest {
+            database.dropData()
         }
 
         afterGroup {
@@ -72,6 +78,10 @@ class BehandlerApiSpek : Spek({
                             behandlerDialogmeldingDTO.orgnummer shouldBeEqualTo fastlegeResponse.fastlegekontor.orgnummer
                             behandlerDialogmeldingDTO.kontor shouldBeEqualTo fastlegeResponse.fastlegekontor.navn
                             behandlerDialogmeldingDTO.type shouldBeEqualTo "FASTLEGE"
+
+                            database.getBehandlerDialogmeldingForArbeidstaker(
+                                UserConstants.ARBEIDSTAKER_FNR,
+                            ).size shouldBeEqualTo 1
                         }
                     }
                     it("should return empty list of BehandlerDialogmelding for arbeidstaker uten fastlege") {
@@ -87,6 +97,10 @@ class BehandlerApiSpek : Spek({
                                 objectMapper.readValue<List<BehandlerDialogmeldingDTO>>(response.content!!)
 
                             behandlerDialogmeldingList.size shouldBeEqualTo 0
+
+                            database.getBehandlerDialogmeldingForArbeidstaker(
+                                UserConstants.ARBEIDSTAKER_UTEN_FASTLEGE_FNR,
+                            ).size shouldBeEqualTo 0
                         }
                     }
 
@@ -106,6 +120,10 @@ class BehandlerApiSpek : Spek({
                                 objectMapper.readValue<List<BehandlerDialogmeldingDTO>>(response.content!!)
 
                             behandlerDialogmeldingList.size shouldBeEqualTo 0
+
+                            database.getBehandlerDialogmeldingForArbeidstaker(
+                                UserConstants.ARBEIDSTAKER_FASTLEGE_UTEN_FORELDREENHET_FNR,
+                            ).size shouldBeEqualTo 0
                         }
                     }
 
@@ -125,6 +143,10 @@ class BehandlerApiSpek : Spek({
                                 objectMapper.readValue<List<BehandlerDialogmeldingDTO>>(response.content!!)
 
                             behandlerDialogmeldingList.size shouldBeEqualTo 0
+
+                            database.getBehandlerDialogmeldingForArbeidstaker(
+                                UserConstants.ARBEIDSTAKER_FASTLEGE_UTEN_PARTNERINFO_FNR,
+                            ).size shouldBeEqualTo 0
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
@@ -38,3 +38,20 @@ class TestDatabaseNotResponding : DatabaseInterface {
     fun stop() {
     }
 }
+
+fun DatabaseInterface.dropData() {
+    val queryList = listOf(
+        """
+        DELETE FROM BEHANDLER_DIALOGMELDING
+        """.trimIndent(),
+        """
+        DELETE FROM BEHANDLER_DIALOGMELDING_ARBEIDSTAKER
+        """.trimIndent(),
+    )
+    this.connection.use { connection ->
+        queryList.forEach { query ->
+            connection.prepareStatement(query).execute()
+        }
+        connection.commit()
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.domain.PersonIdentNumber
 
 object UserConstants {
     val ARBEIDSTAKER_FNR = PersonIdentNumber("12345678912")
+    val ANNEN_ARBEIDSTAKER_FNR = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "7"))
     val ARBEIDSTAKER_VEILEDER_NO_ACCESS = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "1"))
     val ARBEIDSTAKER_UTEN_FASTLEGE_FNR = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "4"))
     val ARBEIDSTAKER_FASTLEGE_UTEN_FORELDREENHET_FNR = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "3"))

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FastlegeResponseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FastlegeResponseGenerator.kt
@@ -7,7 +7,7 @@ fun generateFastlegeResponse(foreldreEnhetHerId: Int? = null) = FastlegeResponse
     fornavn = "Dana",
     mellomnavn = "Katherine",
     etternavn = "Scully",
-    fnr = "fnr",
+    fnr = "12125678911",
     herId = 1337,
     foreldreEnhetHerId = foreldreEnhetHerId,
     helsepersonellregisterId = "hprId",

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/PartnerinfoResponseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/PartnerinfoResponseGenerator.kt
@@ -2,4 +2,4 @@ package no.nav.syfo.testhelper.generator
 
 import no.nav.syfo.behandler.partnerinfo.PartnerinfoResponse
 
-fun generatePartnerinfoResponse() = PartnerinfoResponse(321)
+fun generatePartnerinfoResponse(partnerId: Int = 321) = PartnerinfoResponse(partnerId)


### PR DESCRIPTION
Ved kall for å hente behandler hentes aktiv fastlege med partnerId for arbeidstaker.
Det sjekkes om det finnes behandler i databasen med samme partnerId (og om den er knyttet til arbeidstakeren). 
- Dersom behandler finnes vil denne returneres (og knyttes til arbeidstakeren hvis den ikke er det eller ikke er siste behandler knyttet til til arbeidstakeren)
- Dersom behandler ikke finnes vil denne lagres, knyttes til arbeidstakeren og returneres.