### PR TITLE
Remove unused access policy

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -42,9 +42,6 @@ spec:
       rules:
         - application: fastlegerest
           namespace: teamsykefravr
-          cluster: dev-fss
-        - application: fastlegerest
-          namespace: teamsykefravr
           cluster: dev-gcp
         - application: syfomodiaperson
           namespace: teamsykefravr

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -42,9 +42,6 @@ spec:
       rules:
         - application: fastlegerest
           namespace: teamsykefravr
-          cluster: prod-fss
-        - application: fastlegerest
-          namespace: teamsykefravr
           cluster: prod-gcp
         - application: syfomodiaperson
           namespace: teamsykefravr


### PR DESCRIPTION
Fastlegerest is only in GCP, and the access policy for FSS is therefore removed.