### PR TITLE
Return largest partnerId. Add metric and logging.

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/partnerinfo/PartnerinfoMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/partnerinfo/PartnerinfoMetric.kt
@@ -6,11 +6,21 @@ import no.nav.syfo.metric.METRICS_REGISTRY
 
 const val CAL_PARTNERINFO_BASE = "${METRICS_NS}_call_syfopartnerinfo"
 const val CALL_PARTNERINFO_SUCCESS = "${CAL_PARTNERINFO_BASE}_success_count"
+const val CALL_PARTNERINFO_EMPTY_RESPONSE = "${CAL_PARTNERINFO_BASE}_empty_response_count"
+const val CALL_PARTNERINFO_MULTIPLE_RESPONSE = "${CAL_PARTNERINFO_BASE}_multiple_response_count"
 const val CALL_PARTNERINFO_FAIL = "${CAL_PARTNERINFO_BASE}_fail_count"
 
 val COUNT_CALL_PARTNERINFO_SUCCESS: Counter = Counter
     .builder(CALL_PARTNERINFO_SUCCESS)
     .description("Counts the number of successful calls to Syfopartnerinfo - partnerinfo")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_PARTNERINFO_EMPTY_RESPONSE: Counter = Counter
+    .builder(CALL_PARTNERINFO_EMPTY_RESPONSE)
+    .description("Counts the number of calls to Syfopartnerinfo - partnerinfo with empty response")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_PARTNERINFO_MULTIPLE_RESPONSE: Counter = Counter
+    .builder(CALL_PARTNERINFO_MULTIPLE_RESPONSE)
+    .description("Counts the number of calls to Syfopartnerinfo - partnerinfo with multiple partnerIds in response")
     .register(METRICS_REGISTRY)
 val COUNT_CALL_PARTNERINFO_FAIL: Counter = Counter
     .builder(CALL_PARTNERINFO_FAIL)

--- a/src/test/kotlin/no/nav/syfo/behandler/BehandlerServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandler/BehandlerServiceSpek.kt
@@ -316,6 +316,31 @@ class BehandlerServiceSpek : Spek({
                     pBehandlerForArbeidstakerList.size shouldBeEqualTo 1
                     pBehandlerForArbeidstakerList[0].behandlerRef shouldNotBeEqualTo annenBehandler.behandlerRef
                 }
+                it("lagrer behandler for arbeidstaker når samme behandler er lagret for arbeidstaker, men med annen partnerId") {
+                    val behandler = generateFastlegeResponse(UserConstants.FASTLEGE_FNR).toBehandler(UserConstants.PARTNERID)
+                    val sammeBehandlerAnnenPartnerId =
+                        generateFastlegeResponse(UserConstants.FASTLEGE_FNR).toBehandler(UserConstants.OTHER_PARTNERID)
+                    val existingBehandlerRef =
+                        database.createBehandlerForArbeidstaker(
+                            behandler = behandler,
+                            arbeidstakerPersonIdent = UserConstants.ARBEIDSTAKER_FNR
+                        )
+
+                    behandlerService.createOrGetBehandler(
+                        behandler = sammeBehandlerAnnenPartnerId,
+                        BehandlerArbeidstakerRelasjon(
+                            type = BehandlerType.FASTLEGE,
+                            arbeidstakerPersonident = UserConstants.ARBEIDSTAKER_FNR
+                        ),
+                    )
+
+                    val pBehandlerForArbeidstakerList = database.getBehandlerForArbeidstaker(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                    )
+                    pBehandlerForArbeidstakerList.size shouldBeEqualTo 2
+                    pBehandlerForArbeidstakerList[0].behandlerRef shouldNotBeEqualTo existingBehandlerRef
+                    pBehandlerForArbeidstakerList[1].behandlerRef shouldBeEqualTo existingBehandlerRef
+                }
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -10,6 +10,7 @@ object UserConstants {
     val ARBEIDSTAKER_UTEN_FASTLEGE_FNR = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "4"))
     val ARBEIDSTAKER_MED_FASTLEGE_UTEN_FORELDREENHET = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "3"))
     val ARBEIDSTAKER_MED_FASTLEGE_UTEN_PARTNERINFO = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "6"))
+    val ARBEIDSTAKER_MED_FASTLEGE_MED_FLERE_PARTNERINFO = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "8"))
     val ARBEIDSTAKER_MED_FASTLEGE_UTEN_FNR_HPRID_HERID = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("5", "1"))
 
     const val PERSON_FORNAVN = "Fornavn"
@@ -20,6 +21,7 @@ object UserConstants {
     const val HPRID = 1337
     const val OTHER_HERID = 604
     const val HERID_UTEN_PARTNERINFO = 504
+    const val HERID_MED_FLERE_PARTNERINFO = 704
     const val PARTNERID = 321
     const val OTHER_PARTNERID = 456
     const val VEILEDER_IDENT = "Z999999"

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/FastlegeRestMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/FastlegeRestMock.kt
@@ -28,6 +28,10 @@ private suspend fun PipelineContext<out Unit, ApplicationCall>.fastlegerestRespo
             HttpStatusCode.OK,
             generateFastlegeResponse(UserConstants.HERID_UTEN_PARTNERINFO)
         )
+        UserConstants.ARBEIDSTAKER_MED_FASTLEGE_MED_FLERE_PARTNERINFO.value -> call.respond(
+            HttpStatusCode.OK,
+            generateFastlegeResponse(UserConstants.HERID_MED_FLERE_PARTNERINFO)
+        )
         UserConstants.ARBEIDSTAKER_MED_FASTLEGE_UTEN_FNR_HPRID_HERID.value -> call.respond(
             HttpStatusCode.OK,
             generateFastlegeResponse(null, null, null)

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfopartnerInfoMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfopartnerInfoMock.kt
@@ -30,6 +30,13 @@ class SyfopartnerInfoMock {
                         HttpStatusCode.OK,
                         emptyList<PartnerinfoResponse>()
                     )
+                    UserConstants.HERID_MED_FLERE_PARTNERINFO.toString() -> call.respond(
+                        HttpStatusCode.OK,
+                        listOf(
+                            generatePartnerinfoResponse(UserConstants.PARTNERID),
+                            generatePartnerinfoResponse(UserConstants.OTHER_PARTNERID)
+                        )
+                    )
                     UserConstants.OTHER_HERID.toString() -> call.respond(
                         HttpStatusCode.OK, listOf(generatePartnerinfoResponse(UserConstants.OTHER_PARTNERID))
                     )


### PR DESCRIPTION
I noen tilfeller finner vi flere partnerId-er for en herId - da vil den høyeste id-en være den nyeste og sannsynligvis den mest riktige å bruke for sending av dialogmelding.