### PR TITLE
Make XML generic functions inline

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/kafka/dialogmeldingfrombehandler/KafkaDialogmeldingFromBehandler.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/kafka/dialogmeldingfrombehandler/KafkaDialogmeldingFromBehandler.kt
@@ -64,7 +64,7 @@ fun updateBehandlerOffice(
 
 private fun getPartnerReferanse(fellesformatXML: String, navLogid: String, msgId: String): String {
     return try {
-        val mottakenhetBlokk = getObjectFromXmlString(fellesformatXML, "MottakenhetBlokk", XMLMottakenhetBlokk::class.java)
+        val mottakenhetBlokk = getObjectFromXmlString<XMLMottakenhetBlokk>(fellesformatXML, "MottakenhetBlokk")
         mottakenhetBlokk.partnerReferanse
     } catch (e: Exception) {
         log.warn("Noe gikk galt ved henting av partnerReferanse fra dialogmelding fra behandler: navLogId: $navLogid, msgId: $msgId", e)

--- a/src/main/kotlin/no/nav/syfo/util/JAXB.kt
+++ b/src/main/kotlin/no/nav/syfo/util/JAXB.kt
@@ -25,8 +25,8 @@ object JAXB {
         }
     }
 
-    fun <T> unmarshallObject(xmlStreamReader: XMLStreamReader, wantedClass: Class<T>): T {
-        val jaxbContext: JAXBContext = JAXBContext.newInstance(wantedClass)
+    inline fun <reified T> unmarshallObject(xmlStreamReader: XMLStreamReader): T {
+        val jaxbContext: JAXBContext = JAXBContext.newInstance(T::class.java)
         val unmarshaller: Unmarshaller = jaxbContext.createUnmarshaller()
 
         return unmarshaller.unmarshal(xmlStreamReader) as T

--- a/src/main/kotlin/no/nav/syfo/util/XMLUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/XMLUtil.kt
@@ -6,9 +6,11 @@ import java.io.StringReader
 import javax.xml.stream.XMLInputFactory
 import javax.xml.stream.XMLStreamReader
 
-private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.util.XmlUtil")
+@PublishedApi
+internal val log: Logger = LoggerFactory.getLogger("no.nav.syfo.util.XmlUtil")
 
-private fun <T> getUnmarshalledObject(xmlStreamReader: XMLStreamReader, localName: String, objectClass: Class<T>): T {
+@PublishedApi
+internal inline fun <reified T> getUnmarshalledObject(xmlStreamReader: XMLStreamReader, localName: String): T {
     while (xmlStreamReader.hasNext()) {
         if (xmlStreamReader.isStartElement && xmlStreamReader.localName == localName) {
             break
@@ -16,10 +18,10 @@ private fun <T> getUnmarshalledObject(xmlStreamReader: XMLStreamReader, localNam
         xmlStreamReader.next()
     }
 
-    return JAXB.unmarshallObject(xmlStreamReader, objectClass)
+    return JAXB.unmarshallObject(xmlStreamReader)
 }
 
-fun <T> getObjectFromXmlString(xml: String, localName: String, objectClass: Class<T>): T {
+inline fun <reified T> getObjectFromXmlString(xml: String, localName: String): T {
     val reader = StringReader(xml)
 
     reader.use {
@@ -27,7 +29,7 @@ fun <T> getObjectFromXmlString(xml: String, localName: String, objectClass: Clas
         val xmlStreamReader = xmlInputFactory.createXMLStreamReader(reader)
 
         try {
-            return getUnmarshalledObject(xmlStreamReader, localName, objectClass)
+            return getUnmarshalledObject(xmlStreamReader, localName)
         } catch (e: Exception) {
             log.warn("Fikk en feil ved lesing av xml med XmlStreamReader ${e.message}")
             throw RuntimeException(e)

--- a/src/test/kotlin/no/nav/syfo/util/XMLUtilSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/util/XMLUtilSpek.kt
@@ -14,21 +14,20 @@ class XMLUtilSpek : Spek({
 
         describe("getObjectFromXmlString") {
             it("return object of given class from an xml string") {
-                val mottakenhetBlokk =
-                    getObjectFromXmlString(fellesformatXml, "MottakenhetBlokk", XMLMottakenhetBlokk::class.java)
-                val notat = getObjectFromXmlString(completeFellesformatXml, "Notat", XMLNotat::class.java)
+                val mottakenhetBlokk = getObjectFromXmlString<XMLMottakenhetBlokk>(fellesformatXml, "MottakenhetBlokk")
+                val notat = getObjectFromXmlString<XMLNotat>(completeFellesformatXml, "Notat")
 
                 mottakenhetBlokk.partnerReferanse shouldBeEqualTo partnerRef
                 notat.dokIdNotat shouldBeEqualTo dokIdNotat
             }
             it("throw exception if localName doesn't match class") {
                 assertThrows(RuntimeException::class.java) {
-                    getObjectFromXmlString(completeFellesformatXml, "partnerReferanse", XMLMottakenhetBlokk::class.java)
+                    getObjectFromXmlString<XMLMottakenhetBlokk>(completeFellesformatXml, "partnerReferanse")
                 }
             }
             it("throw exception if wanted tag isn't found") {
                 assertThrows(RuntimeException::class.java) {
-                    getObjectFromXmlString(completeFellesformatXml, "NotXmlClass", NotXmlClass::class.java)
+                    getObjectFromXmlString<NotXmlClass>(completeFellesformatXml, "NotXmlClass")
                 }
             }
         }


### PR DESCRIPTION
Da slipper vi å sende inn klassen som parameter til funksjonene.
Gjør private funksjoner om til internal med PublishedApi-annotasjon så de kan kalles fra inline funksjoner.

https://stackoverflow.com/questions/45949584/how-does-the-reified-keyword-in-kotlin-work