### PR TITLE
Remove role to patient section from dialogmelding to behandler

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmelding/converter/MottakerConverter.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmelding/converter/MottakerConverter.kt
@@ -45,12 +45,6 @@ fun createReceiver(
                 )
                 .withHealthcareProfessional(
                     factory.createXMLHealthcareProfessional()
-                        .withRoleToPatient(
-                            factory.createXMLCV()
-                                .withV("6")
-                                .withS("2.16.578.1.12.4.1.1.9034")
-                                .withDN("Fastlege")
-                        )
                         .withFamilyName(melding.behandler.etternavn)
                         .withMiddleName(melding.behandler.mellomnavn)
                         .withGivenName(melding.behandler.fornavn)

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingAvlysningXml.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingAvlysningXml.kt
@@ -45,7 +45,6 @@ fun defaultFellesformatDialogmeldingAvlysningXmlRegex(): Regex {
             "                        <ns2:City>poststed</ns2:City>\n" +
             "                    </ns2:Address>\n" +
             "                    <ns2:HealthcareProfessional>\n" +
-            "                        <ns2:RoleToPatient V=\"6\" S=\"2.16.578.1.12.4.1.1.9034\" DN=\"Fastlege\"/>\n" +
             "                        <ns2:FamilyName>Scully</ns2:FamilyName>\n" +
             "                        <ns2:MiddleName>Katherine</ns2:MiddleName>\n" +
             "                        <ns2:GivenName>Dana</ns2:GivenName>\n" +

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingEndreTidStedXml.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingEndreTidStedXml.kt
@@ -45,7 +45,6 @@ fun defaultFellesformatDialogmeldingEndreTidStedXmlRegex(): Regex {
             "                        <ns2:City>poststed</ns2:City>\n" +
             "                    </ns2:Address>\n" +
             "                    <ns2:HealthcareProfessional>\n" +
-            "                        <ns2:RoleToPatient V=\"6\" S=\"2.16.578.1.12.4.1.1.9034\" DN=\"Fastlege\"/>\n" +
             "                        <ns2:FamilyName>Scully</ns2:FamilyName>\n" +
             "                        <ns2:MiddleName>Katherine</ns2:MiddleName>\n" +
             "                        <ns2:GivenName>Dana</ns2:GivenName>\n" +

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingReferatXml.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingReferatXml.kt
@@ -45,7 +45,6 @@ fun defaultFellesformatDialogmeldingReferatXmlRegex(): Regex {
             "                        <ns2:City>poststed</ns2:City>\n" +
             "                    </ns2:Address>\n" +
             "                    <ns2:HealthcareProfessional>\n" +
-            "                        <ns2:RoleToPatient V=\"6\" S=\"2.16.578.1.12.4.1.1.9034\" DN=\"Fastlege\"/>\n" +
             "                        <ns2:FamilyName>Scully</ns2:FamilyName>\n" +
             "                        <ns2:MiddleName>Katherine</ns2:MiddleName>\n" +
             "                        <ns2:GivenName>Dana</ns2:GivenName>\n" +

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingXml.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingXml.kt
@@ -44,7 +44,6 @@ fun defaultFellesformatDialogmeldingXmlRegex(): Regex {
             "                        <ns2:City>poststed</ns2:City>\n" +
             "                    </ns2:Address>\n" +
             "                    <ns2:HealthcareProfessional>\n" +
-            "                        <ns2:RoleToPatient V=\"6\" S=\"2.16.578.1.12.4.1.1.9034\" DN=\"Fastlege\"/>\n" +
             "                        <ns2:FamilyName>Scully</ns2:FamilyName>\n" +
             "                        <ns2:MiddleName>Katherine</ns2:MiddleName>\n" +
             "                        <ns2:GivenName>Dana</ns2:GivenName>\n" +


### PR DESCRIPTION
According to the documentation:
nav-veiledning-bruk-av-dialogmelding-ia-v-1-5-04.12.2015.pdf, the section
is not in use.

Co-authored-by: John Martin Lindseth <john.martin.lindseth@nav.no>