### PR TITLE
Cleanup plugins and simplify server mocks

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/api/ApiPlugins.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiPlugins.kt
@@ -1,78 +1,20 @@
-package no.nav.syfo.application.api.authentication
+package no.nav.syfo.application.api
 
-import com.auth0.jwk.JwkProviderBuilder
-import com.auth0.jwt.JWT
 import io.ktor.client.plugins.*
 import io.ktor.http.*
 import io.ktor.serialization.jackson.*
 import io.ktor.server.application.*
-import io.ktor.server.auth.*
-import io.ktor.server.auth.jwt.*
 import io.ktor.server.metrics.micrometer.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
-import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.behandler.api.access.ForbiddenAccessVeilederException
 import no.nav.syfo.behandler.api.person.access.ForbiddenPersonAPIConsumer
-import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.metric.METRICS_REGISTRY
 import no.nav.syfo.util.configure
 import no.nav.syfo.util.getCallId
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import java.net.URL
 import java.time.Duration
-import java.util.concurrent.TimeUnit
-
-private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.application.api.authentication")
-
-fun Application.installJwtAuthentication(
-    jwtIssuerList: List<JwtIssuer>,
-) {
-    install(Authentication) {
-        jwtIssuerList.forEach { jwtIssuer ->
-            configureJwt(
-                jwtIssuer = jwtIssuer,
-            )
-        }
-    }
-}
-
-fun AuthenticationConfig.configureJwt(
-    jwtIssuer: JwtIssuer,
-) {
-    val jwkProviderSelvbetjening = JwkProviderBuilder(URL(jwtIssuer.wellKnown.jwks_uri))
-        .cached(10, 24, TimeUnit.HOURS)
-        .rateLimited(10, 1, TimeUnit.MINUTES)
-        .build()
-    jwt(name = jwtIssuer.jwtIssuerType.name) {
-        verifier(jwkProviderSelvbetjening, jwtIssuer.wellKnown.issuer)
-        validate { credential ->
-            if (hasExpectedAudience(credential, jwtIssuer.acceptedAudienceList)) {
-                JWTPrincipal(credential.payload)
-            } else {
-                log.warn(
-                    "Auth: Unexpected audience for jwt {}, {}",
-                    StructuredArguments.keyValue("issuer", credential.payload.issuer),
-                    StructuredArguments.keyValue("audience", credential.payload.audience)
-                )
-                null
-            }
-        }
-    }
-}
-
-fun hasExpectedAudience(credentials: JWTCredential, expectedAudience: List<String>): Boolean {
-    return expectedAudience.any { credentials.payload.audience.contains(it) }
-}
-
-fun ApplicationCall.personIdent(): PersonIdentNumber? {
-    val token = this.request.headers[HttpHeaders.Authorization]?.removePrefix("Bearer ")
-    val decodedJWT = JWT.decode(token)
-    return decodedJWT.claims["pid"]?.asString()?.let { PersonIdentNumber(it) }
-}
 
 fun Application.installMetrics() {
     install(MicrometerMetrics) {

--- a/src/main/kotlin/no/nav/syfo/application/api/authentication/ApiAuthenticationPlugin.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/authentication/ApiAuthenticationPlugin.kt
@@ -1,0 +1,53 @@
+package no.nav.syfo.application.api.authentication
+
+import com.auth0.jwk.JwkProviderBuilder
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.auth.jwt.*
+import net.logstash.logback.argument.StructuredArguments
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.net.URL
+import java.util.concurrent.TimeUnit
+
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.application.api.authentication")
+
+fun Application.installJwtAuthentication(
+    jwtIssuerList: List<JwtIssuer>,
+) {
+    install(Authentication) {
+        jwtIssuerList.forEach { jwtIssuer ->
+            configureJwt(
+                jwtIssuer = jwtIssuer,
+            )
+        }
+    }
+}
+
+fun AuthenticationConfig.configureJwt(
+    jwtIssuer: JwtIssuer,
+) {
+    val jwkProviderSelvbetjening = JwkProviderBuilder(URL(jwtIssuer.wellKnown.jwks_uri))
+        .cached(10, 24, TimeUnit.HOURS)
+        .rateLimited(10, 1, TimeUnit.MINUTES)
+        .build()
+    jwt(name = jwtIssuer.jwtIssuerType.name) {
+        verifier(jwkProviderSelvbetjening, jwtIssuer.wellKnown.issuer)
+        validate { credential ->
+            if (hasExpectedAudience(credential, jwtIssuer.acceptedAudienceList)) {
+                JWTPrincipal(credential.payload)
+            } else {
+                log.warn(
+                    "Auth: Unexpected audience for jwt {}, {}",
+                    StructuredArguments.keyValue("issuer", credential.payload.issuer),
+                    StructuredArguments.keyValue("audience", credential.payload.audience)
+                )
+                null
+            }
+        }
+    }
+}
+
+fun hasExpectedAudience(credentials: JWTCredential, expectedAudience: List<String>): Boolean {
+    return expectedAudience.any { credentials.payload.audience.contains(it) }
+}

--- a/src/main/kotlin/no/nav/syfo/behandler/api/person/PersonBehandlerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/person/PersonBehandlerApi.kt
@@ -4,12 +4,10 @@ import io.ktor.server.application.*
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.nav.syfo.application.api.authentication.personIdent
 import no.nav.syfo.behandler.BehandlerService
 import no.nav.syfo.behandler.api.person.access.PersonAPIConsumerAccessService
 import no.nav.syfo.behandler.domain.*
-import no.nav.syfo.util.getBearerHeader
-import no.nav.syfo.util.getCallId
+import no.nav.syfo.util.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -28,7 +26,7 @@ fun Route.registerPersonBehandlerApi(
             try {
                 val token = getBearerHeader()
                     ?: throw IllegalArgumentException("No Authorization header supplied")
-                val requestPersonIdent = call.personIdent()
+                val requestPersonIdent = call.personIdentFromToken()
                     ?: throw IllegalArgumentException("No PersonIdent found in token")
 
                 personAPIConsumerAccessService.validateConsumerApplicationClientId(

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -1,9 +1,11 @@
 package no.nav.syfo.util
 
+import com.auth0.jwt.JWT
 import io.ktor.server.application.*
 import io.ktor.http.*
 import io.ktor.util.pipeline.*
 import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.domain.PersonIdentNumber
 
 const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
 const val NAV_PERSONIDENT_HEADER = "nav-personident"
@@ -23,6 +25,12 @@ fun PipelineContext<out Unit, ApplicationCall>.getBearerHeader(): String? {
 
 fun PipelineContext<out Unit, ApplicationCall>.getPersonIdentHeader(): String? {
     return this.call.request.headers[NAV_PERSONIDENT_HEADER]
+}
+
+fun ApplicationCall.personIdentFromToken(): PersonIdentNumber? {
+    val token = this.request.headers[HttpHeaders.Authorization]?.removePrefix("Bearer ")
+    val decodedJWT = JWT.decode(token)
+    return decodedJWT.claims["pid"]?.asString()?.let { PersonIdentNumber(it) }
 }
 
 fun bearerHeader(token: String) = "Bearer $token"

--- a/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
@@ -3,12 +3,13 @@ package no.nav.syfo.testhelper
 import io.ktor.server.netty.*
 import no.nav.common.KafkaEnvironment
 import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.Environment
 import no.nav.syfo.testhelper.mocks.*
 
 class ExternalMockEnvironment private constructor() {
     val applicationState: ApplicationState = testAppState()
     val database = TestDatabase()
-    val embeddedEnvironment: KafkaEnvironment = testKafka()
+    private val embeddedEnvironment: KafkaEnvironment = testKafka()
     private val azureAdMock = AzureAdMock()
 
     private val fastlegeRestMock = FastlegeRestMock()
@@ -24,14 +25,16 @@ class ExternalMockEnvironment private constructor() {
         pdlMock.name to pdlMock.server,
     )
 
-    val environment = testEnvironment(
-        azureOpenidConfigTokenEndpoint = azureAdMock.url,
-        kafkaBootstrapServers = embeddedEnvironment.brokersURL,
-        fastlegeRestUrl = fastlegeRestMock.url,
-        syfoPartnerinfoUrl = syfopartnerInfoMock.url,
-        syfoTilgangskontrollUrl = syfoTilgangskontrollMock.url,
-        pdlUrl = pdlMock.url,
-    )
+    val environment: Environment by lazy {
+        testEnvironment(
+            azureOpenidConfigTokenEndpoint = azureAdMock.url(),
+            kafkaBootstrapServers = embeddedEnvironment.brokersURL,
+            fastlegeRestUrl = fastlegeRestMock.url(),
+            syfoPartnerinfoUrl = syfopartnerInfoMock.url(),
+            syfoTilgangskontrollUrl = syfoTilgangskontrollMock.url(),
+            pdlUrl = pdlMock.url(),
+        )
+    }
     val wellKnownInternalAzureAD = wellKnownInternalAzureAD()
     val wellKnownInternalIdportenTokenX = wellKnownInternalIdportenTokenX()
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.testhelper
 
 import no.nav.syfo.application.*
-import java.net.ServerSocket
 
 fun testEnvironment(
     azureOpenidConfigTokenEndpoint: String,
@@ -57,7 +56,3 @@ fun testAppState() = ApplicationState(
     alive = true,
     ready = true,
 )
-
-fun getRandomPort() = ServerSocket(0).use {
-    it.localPort
-}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/AzureADMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/AzureADMock.kt
@@ -1,14 +1,10 @@
 package no.nav.syfo.testhelper.mocks
 
 import io.ktor.server.application.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.application.api.authentication.WellKnown
-import no.nav.syfo.application.api.authentication.installContentNegotiation
 import no.nav.syfo.client.azuread.AzureAdTokenResponse
-import no.nav.syfo.testhelper.getRandomPort
 import java.nio.file.Paths
 
 fun wellKnownInternalAzureAD(): WellKnown {
@@ -22,32 +18,17 @@ fun wellKnownInternalAzureAD(): WellKnown {
     )
 }
 
-class AzureAdMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-
+class AzureAdMock : MockServer() {
     private val azureAdTokenResponse = AzureAdTokenResponse(
         access_token = "token",
         expires_in = 3600,
         token_type = "type",
     )
 
-    val name = "azuread"
-    val server = mockAzureAdServer(port = port)
-
-    private fun mockAzureAdServer(
-        port: Int
-    ): NettyApplicationEngine {
-        return embeddedServer(
-            factory = Netty,
-            port = port,
-        ) {
-            installContentNegotiation()
-            routing {
-                post {
-                    call.respond(azureAdTokenResponse)
-                }
-            }
+    override val name = "azuread"
+    override val routingConfiguration: Routing.() -> Unit = {
+        post {
+            call.respond(azureAdTokenResponse)
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/FastlegeRestMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/FastlegeRestMock.kt
@@ -2,17 +2,13 @@ package no.nav.syfo.testhelper.mocks
 
 import io.ktor.server.application.*
 import io.ktor.http.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.pipeline.*
-import no.nav.syfo.application.api.authentication.installContentNegotiation
 import no.nav.syfo.behandler.fastlege.FastlegeClient.Companion.FASTLEGE_PATH
 import no.nav.syfo.behandler.fastlege.FastlegeClient.Companion.FASTLEGE_SYSTEM_PATH
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.generator.generateFastlegeResponse
-import no.nav.syfo.testhelper.getRandomPort
 import no.nav.syfo.util.getPersonIdentHeader
 
 private suspend fun PipelineContext<out Unit, ApplicationCall>.fastlegerestResponse() {
@@ -44,23 +40,14 @@ private suspend fun PipelineContext<out Unit, ApplicationCall>.fastlegerestRespo
     }
 }
 
-class FastlegeRestMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-
-    val name = "fastlegerest"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            get(FASTLEGE_PATH) {
-                this.fastlegerestResponse()
-            }
-            get(FASTLEGE_SYSTEM_PATH) {
-                this.fastlegerestResponse()
-            }
+class FastlegeRestMock : MockServer() {
+    override val name = "fastlegerest"
+    override val routingConfiguration: Routing.() -> Unit = {
+        get(FASTLEGE_PATH) {
+            this.fastlegerestResponse()
+        }
+        get(FASTLEGE_SYSTEM_PATH) {
+            this.fastlegerestResponse()
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/MockServer.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/MockServer.kt
@@ -1,0 +1,25 @@
+package no.nav.syfo.testhelper.mocks
+
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.routing.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.application.api.installContentNegotiation
+
+abstract class MockServer {
+    val server = embeddedServer(
+        factory = Netty,
+        port = 0,
+    ) {
+        installContentNegotiation()
+        install(Routing, routingConfiguration)
+    }
+
+    abstract val name: String
+    abstract val routingConfiguration: Routing.() -> Unit
+    fun url(): String {
+        val port = runBlocking { server.resolvedConnectors().first().port }
+        return "http://localhost:$port"
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/PdlMock.kt
@@ -1,27 +1,15 @@
 package no.nav.syfo.testhelper.mocks
 
 import io.ktor.server.application.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.nav.syfo.application.api.authentication.installContentNegotiation
 import no.nav.syfo.testhelper.generator.generatePdlPersonResponse
-import no.nav.syfo.testhelper.getRandomPort
 
-class PdlMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-    val name = "pdl"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port
-    ) {
-        installContentNegotiation()
-        routing {
-            post {
-                call.respond(generatePdlPersonResponse())
-            }
+class PdlMock : MockServer() {
+    override val name = "pdl"
+    override val routingConfiguration: Routing.() -> Unit = {
+        post {
+            call.respond(generatePdlPersonResponse())
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfoTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfoTilgangskontrollMock.kt
@@ -1,37 +1,24 @@
 package no.nav.syfo.testhelper.mocks
 
 import io.ktor.server.application.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.nav.syfo.application.api.authentication.installContentNegotiation
 import no.nav.syfo.client.veiledertilgang.Tilgang
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.TILGANGSKONTROLL_PERSON_PATH
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
-import no.nav.syfo.testhelper.getRandomPort
 import no.nav.syfo.util.getPersonIdentHeader
 
-class SyfoTilgangskontrollMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-
-    val name = "syfotilgangskontroll"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            get(TILGANGSKONTROLL_PERSON_PATH) {
-                when (getPersonIdentHeader()) {
-                    ARBEIDSTAKER_VEILEDER_NO_ACCESS.value -> call.respond(
-                        Tilgang(harTilgang = false)
-                    )
-                    else -> call.respond(
-                        Tilgang(harTilgang = true)
-                    )
-                }
+class SyfoTilgangskontrollMock : MockServer() {
+    override val name = "syfotilgangskontroll"
+    override val routingConfiguration: Routing.() -> Unit = {
+        get(TILGANGSKONTROLL_PERSON_PATH) {
+            when (getPersonIdentHeader()) {
+                ARBEIDSTAKER_VEILEDER_NO_ACCESS.value -> call.respond(
+                    Tilgang(harTilgang = false)
+                )
+                else -> call.respond(
+                    Tilgang(harTilgang = true)
+                )
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfopartnerInfoMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfopartnerInfoMock.kt
@@ -2,48 +2,35 @@ package no.nav.syfo.testhelper.mocks
 
 import io.ktor.server.application.*
 import io.ktor.http.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.nav.syfo.application.api.authentication.installContentNegotiation
 import no.nav.syfo.behandler.partnerinfo.PartnerinfoClient.Companion.BEHANDLER_PATH
 import no.nav.syfo.behandler.partnerinfo.PartnerinfoResponse
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.generator.generatePartnerinfoResponse
-import no.nav.syfo.testhelper.getRandomPort
 
-class SyfopartnerInfoMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-
-    val name = "syfopartnerinfo"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            get(BEHANDLER_PATH) {
-                when (call.parameters["herid"]) {
-                    UserConstants.HERID_UTEN_PARTNERINFO.toString() -> call.respond(
-                        HttpStatusCode.OK,
-                        emptyList<PartnerinfoResponse>()
+class SyfopartnerInfoMock : MockServer() {
+    override val name = "syfopartnerinfo"
+    override val routingConfiguration: Routing.() -> Unit = {
+        get(BEHANDLER_PATH) {
+            when (call.parameters["herid"]) {
+                UserConstants.HERID_UTEN_PARTNERINFO.toString() -> call.respond(
+                    HttpStatusCode.OK,
+                    emptyList<PartnerinfoResponse>()
+                )
+                UserConstants.HERID_MED_FLERE_PARTNERINFO.toString() -> call.respond(
+                    HttpStatusCode.OK,
+                    listOf(
+                        generatePartnerinfoResponse(UserConstants.PARTNERID.value),
+                        generatePartnerinfoResponse(UserConstants.OTHER_PARTNERID.value)
                     )
-                    UserConstants.HERID_MED_FLERE_PARTNERINFO.toString() -> call.respond(
-                        HttpStatusCode.OK,
-                        listOf(
-                            generatePartnerinfoResponse(UserConstants.PARTNERID.value),
-                            generatePartnerinfoResponse(UserConstants.OTHER_PARTNERID.value)
-                        )
-                    )
-                    UserConstants.OTHER_HERID.toString() -> call.respond(
-                        HttpStatusCode.OK, listOf(generatePartnerinfoResponse(UserConstants.OTHER_PARTNERID.value))
-                    )
-                    else -> call.respond(
-                        HttpStatusCode.OK, listOf(generatePartnerinfoResponse(UserConstants.PARTNERID.value))
-                    )
-                }
+                )
+                UserConstants.OTHER_HERID.toString() -> call.respond(
+                    HttpStatusCode.OK, listOf(generatePartnerinfoResponse(UserConstants.OTHER_PARTNERID.value))
+                )
+                else -> call.respond(
+                    HttpStatusCode.OK, listOf(generatePartnerinfoResponse(UserConstants.PARTNERID.value))
+                )
             }
         }
     }


### PR DESCRIPTION
Flyttet authentication til egen plugin-fil og renamet features til plugin (ref Ktor 2.0).
Samlet felles mock-server-oppsett i egen klasse og byttet til Ktor 2.0 random port.