### PR TITLE
Remove name capitalization for sykmelding

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/kafka/sykmelding/KafkaBehandlerSykmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/kafka/sykmelding/KafkaBehandlerSykmelding.kt
@@ -6,7 +6,6 @@ import no.nav.syfo.behandler.BehandlerService
 import no.nav.syfo.behandler.domain.*
 import no.nav.syfo.behandler.kafka.kafkaSykmeldingConsumerConfig
 import no.nav.syfo.domain.*
-import no.nav.syfo.util.capitalize
 import org.apache.kafka.clients.consumer.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -110,9 +109,9 @@ private fun createAndStoreBehandlerFromSykmelding(
     val sykmelder = Behandler(
         behandlerRef = UUID.randomUUID(),
         personident = PersonIdentNumber(sykmeldingBehandler.fnr),
-        fornavn = sykmeldingBehandler.fornavn.capitalize(),
-        mellomnavn = sykmeldingBehandler.mellomnavn?.capitalize(),
-        etternavn = sykmeldingBehandler.etternavn.capitalize(),
+        fornavn = sykmeldingBehandler.fornavn,
+        mellomnavn = sykmeldingBehandler.mellomnavn,
+        etternavn = sykmeldingBehandler.etternavn,
         herId = sykmeldingBehandler.her?.toInt(),
         hprId = sykmeldingBehandler.hpr?.toInt(),
         telefon = sykmeldingBehandler.tlf?.removePrefix("tel:"),

--- a/src/main/kotlin/no/nav/syfo/util/StringUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/StringUtil.kt
@@ -1,8 +1,0 @@
-package no.nav.syfo.util
-
-import java.util.*
-
-fun String.capitalize(): String {
-    return this.lowercase()
-        .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
-}

--- a/src/test/kotlin/no/nav/syfo/behandler/kafka/sykmelding/KafkaSykmeldingSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandler/kafka/sykmelding/KafkaSykmeldingSpek.kt
@@ -114,7 +114,7 @@ class KafkaSykmeldingSpek : Spek({
                         behandlerRelasjonAfter.size shouldBeEqualTo 1
                         behandlerRelasjonAfter[0].type shouldBeEqualTo BehandlerArbeidstakerRelasjonstype.SYKMELDER.name
                     }
-                    it("should capitalize behandlernavn and remove telephone-prefix") {
+                    it("should remove telephone-prefix") {
                         val sykmelding = generateSykmeldingDTO(
                             uuid = UUID.randomUUID(),
                             fornavnLege = "ANNE",
@@ -134,8 +134,8 @@ class KafkaSykmeldingSpek : Spek({
                         val behandlerAfter = database.getBehandlerByArbeidstaker(PersonIdentNumber(sykmelding.personNrPasient))
                         behandlerAfter.size shouldBeEqualTo 1
                         behandlerAfter[0].personident shouldBeEqualTo sykmelding.personNrLege
-                        behandlerAfter[0].fornavn shouldBeEqualTo "Anne"
-                        behandlerAfter[0].etternavn shouldBeEqualTo "Lege"
+                        behandlerAfter[0].fornavn shouldBeEqualTo sykmelding.sykmelding.behandler.fornavn
+                        behandlerAfter[0].etternavn shouldBeEqualTo sykmelding.sykmelding.behandler.etternavn
                         behandlerAfter[0].telefon shouldBeEqualTo "99999999"
                     }
                     it("should add second behandler from incoming sykmelding") {


### PR DESCRIPTION
Har kikket litt på det vi har i prod-databasen, og det viser seg at vi *ikke* kapitaliserer navn for leger fra fastlegerest (fastlegerrest kapitaliserer navn, men bare for pasient/arbeidstaker), så de behandlerne vi har i databasen til isdialogmelding nå har navn med store bokstaver. Så da tror jeg det riktigste blir å ta inn behandlere fra sykmeldinger as-is, og så kan vi se nærmere på behovet for å gjøre noe med disse navnene før de sendes til frontend (evnt transformere i frontend).