### PR TITLE
Process limited number of sykmelding

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -77,7 +77,7 @@ spec:
     - name: KTOR_ENV
       value: "production"
     - name: TOGGLE_KAFKA_PROCESSING_SYKMELDING_ENABLED
-      value: "false"
+      value: "true"
     - name: TOGGLE_KAFKA_PROCESSING_DIALOGMELDING_ENABLED
       value: "false"
     - name: MQGATEWAY_NAME

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationUtils.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationUtils.kt
@@ -8,14 +8,19 @@ private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.application")
 
 fun launchBackgroundTask(
     applicationState: ApplicationState,
-    action: suspend CoroutineScope.() -> Unit
+    finallyNotReady: Boolean = true,
+    action: suspend CoroutineScope.() -> Unit,
 ): Job = GlobalScope.launch {
     try {
         action()
     } catch (ex: Exception) {
         log.error("Exception received while launching background task. Terminating application.", ex)
     } finally {
-        applicationState.alive = false
-        applicationState.ready = false
+        if (finallyNotReady) {
+            applicationState.alive = false
+            applicationState.ready = false
+        } else {
+            log.info("Background task exited normally")
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/application/database/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/application/database/Database.kt
@@ -11,7 +11,7 @@ data class DatabaseConfig(
     val jdbcUrl: String,
     val password: String,
     val username: String,
-    val poolSize: Int = 2,
+    val poolSize: Int = 4,
 )
 
 class Database(

--- a/src/main/kotlin/no/nav/syfo/behandler/kafka/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/kafka/KafkaModule.kt
@@ -27,7 +27,10 @@ fun launchKafkaTaskSykmelding(
     applicationEnvironmentKafka: ApplicationEnvironmentKafka,
     behandlerService: BehandlerService,
 ) {
-    launchBackgroundTask(applicationState = applicationState) {
+    launchBackgroundTask(
+        applicationState = applicationState,
+        finallyNotReady = false,
+    ) {
         blockingApplicationLogicSykmelding(
             applicationState = applicationState,
             applicationEnvironmentKafka = applicationEnvironmentKafka,


### PR DESCRIPTION
Ideen er å deploye dette i prod for å få prosessert 1000 sykmeldinger per pod. Dette vil generere behandlere i databasen som vi kan sjekke om ble som forventet etterpå. 

Planlegger å revertere det meste av koden etterpå i en ny PR, og så komme tilbake med enda en PR som skrur det på slik at hele backlog'en av sykmeldinger blir prosessert (det er antakelig flere millioner).