### PR TITLE
Disable sykmelding prod (temporarily)

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -77,7 +77,7 @@ spec:
     - name: KTOR_ENV
       value: "production"
     - name: TOGGLE_KAFKA_PROCESSING_SYKMELDING_ENABLED
-      value: "true"
+      value: "false"
     - name: TOGGLE_KAFKA_PROCESSING_DIALOGMELDING_ENABLED
       value: "false"
     - name: MQGATEWAY_NAME


### PR DESCRIPTION
Skru av midlertidig mens vi undersøker problemet med at cronJob'en ikke fungerer som den skal.