### PR TITLE
Add behandlerIdenter to xml only if not null

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmelding/converter/MottakerConverter.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmelding/converter/MottakerConverter.kt
@@ -44,11 +44,11 @@ fun createReceiver(
                         .withCity(melding.behandler.kontor.poststed)
                 )
                 .withHealthcareProfessional(
-                    factory.createXMLHealthcareProfessional()
-                        .withFamilyName(melding.behandler.etternavn)
-                        .withMiddleName(melding.behandler.mellomnavn)
-                        .withGivenName(melding.behandler.fornavn)
-                        .withIdent(
+                    factory.createXMLHealthcareProfessional().apply {
+                        withFamilyName(melding.behandler.etternavn)
+                        withMiddleName(melding.behandler.mellomnavn)
+                        withGivenName(melding.behandler.fornavn)
+                        withIdent(
                             factory.createXMLIdent()
                                 .withId(melding.behandler.personident!!.value)
                                 .withTypeId(
@@ -58,16 +58,32 @@ fun createReceiver(
                                         .withV("FNR")
                                 )
                         )
-                        .withIdent(
-                            factory.createXMLIdent()
-                                .withId(melding.behandler.hprId.toString())
-                                .withTypeId(
-                                    factory.createXMLCV()
-                                        .withDN("HPR-nummer")
-                                        .withS("2.16.578.1.12.4.1.1.8116")
-                                        .withV("HPR")
-                                )
-                        )
+                        if (melding.behandler.hprId != null) {
+                            withIdent(
+                                factory.createXMLIdent()
+                                    .withId(melding.behandler.hprId.toString())
+                                    .withTypeId(
+                                        factory.createXMLCV()
+                                            .withDN("HPR-nummer")
+                                            .withS("2.16.578.1.12.4.1.1.8116")
+                                            .withV("HPR")
+                                    )
+                            )
+                        }
+                        if (melding.behandler.herId != null) {
+                            withIdent(
+                                factory.createXMLIdent()
+                                    .withId(melding.behandler.herId.toString())
+                                    .withTypeId(
+                                        factory.createXMLCV()
+                                            .withDN("Identifikator fra Helsetjenesteenhetsregisteret")
+                                            .withS("2.16.578.1.12.4.1.1.8116")
+                                            .withV("HER")
+                                    )
+
+                            )
+                        }
+                    }
                 )
         )
 }

--- a/src/test/kotlin/no/nav/syfo/dialogmelding/DialogmeldingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmelding/DialogmeldingServiceSpek.kt
@@ -14,7 +14,7 @@ import no.nav.syfo.testhelper.generator.*
 import org.junit.Assert.assertTrue
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.util.UUID
+import java.util.*
 
 object DialogmeldingServiceSpek : Spek({
 

--- a/src/test/kotlin/no/nav/syfo/dialogmelding/converter/FellesformatConverterSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmelding/converter/FellesformatConverterSpek.kt
@@ -1,0 +1,57 @@
+package no.nav.syfo.dialogmelding.converter
+
+import no.nav.syfo.behandler.domain.DialogmeldingToBehandlerBestilling
+import no.nav.syfo.behandler.kafka.dialogmeldingtobehandlerbestilling.toDialogmeldingToBehandlerBestilling
+import no.nav.syfo.domain.PartnerId
+import no.nav.syfo.domain.Personident
+import no.nav.syfo.fellesformat.Fellesformat
+import no.nav.syfo.testhelper.generator.*
+import no.nav.syfo.util.JAXB
+import org.junit.Assert.assertTrue
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.*
+
+class FellesformatConverterSpek : Spek({
+    val arbeidstakerPersonident = Personident("01010112345")
+
+    describe("FellesformatConverter for dialogmelding creates melding to behandler, with arbeidstaker as patient") {
+        it("create XMLEIFellesformat without herID as ident for behandler") {
+            val melding = createDialogmeldingToBehandlerBestilling(
+                arbeidstakerPersonident = arbeidstakerPersonident,
+                herId = null,
+            )
+            val arbeidstaker = generateArbeidstaker(arbeidstakerPersonident)
+            val expectedFellesformatMessageAsRegex = defaultFellesformatDialogmeldingNoHerIdXmlRegex()
+
+            val actualXMLEIFellesformat = createFellesformat(
+                melding,
+                arbeidstaker,
+            )
+            val actualFellesformat = Fellesformat(actualXMLEIFellesformat, JAXB::marshallDialogmelding1_0)
+
+            assertTrue(
+                expectedFellesformatMessageAsRegex.matches(actualFellesformat.message!!),
+            )
+        }
+    }
+})
+
+fun createDialogmeldingToBehandlerBestilling(
+    arbeidstakerPersonident: Personident,
+    herId: Int? = 77,
+): DialogmeldingToBehandlerBestilling {
+    val behandlerRef = UUID.randomUUID()
+
+    return generateDialogmeldingToBehandlerBestillingDTO(
+        behandlerRef = behandlerRef,
+        uuid = UUID.randomUUID(),
+        arbeidstakerPersonident = arbeidstakerPersonident,
+    ).toDialogmeldingToBehandlerBestilling(
+        behandler = generateBehandler(
+            behandlerRef = behandlerRef,
+            partnerId = PartnerId(1),
+            herId = herId,
+        ),
+    )
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/ArbeidstakerGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/ArbeidstakerGenerator.kt
@@ -1,0 +1,16 @@
+package no.nav.syfo.testhelper.generator
+
+import no.nav.syfo.behandler.domain.*
+import no.nav.syfo.domain.*
+import no.nav.syfo.testhelper.UserConstants
+import java.time.OffsetDateTime
+
+fun generateArbeidstaker(
+    arbeidstakerPersonident: Personident = Personident("01010112345"),
+) = Arbeidstaker(
+    arbeidstakerPersonident = arbeidstakerPersonident,
+    fornavn = UserConstants.PERSON_FORNAVN,
+    mellomnavn = UserConstants.PERSON_MELLOMNAVN,
+    etternavn = UserConstants.PERSON_ETTERNAVN,
+    mottatt = OffsetDateTime.now(),
+)

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/BehandlerGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/BehandlerGenerator.kt
@@ -10,7 +10,7 @@ fun generateBehandler(
     partnerId: PartnerId,
     dialogmeldingEnabled: Boolean = true,
     personident: Personident = Personident("12125678911"),
-    herId: Int = 77,
+    herId: Int? = 77,
     hprId: Int = 9,
 ) = Behandler(
     behandlerRef = behandlerRef,

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingAvlysningXml.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingAvlysningXml.kt
@@ -56,6 +56,10 @@ fun defaultFellesformatDialogmeldingAvlysningXmlRegex(): Regex {
             "                            <ns2:Id>9</ns2:Id>\n" +
             "                            <ns2:TypeId V=\"HPR\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"HPR-nummer\"/>\n" +
             "                        </ns2:Ident>\n" +
+            "                        <ns2:Ident>\n" +
+            "                            <ns2:Id>77</ns2:Id>\n" +
+            "                            <ns2:TypeId V=\"HER\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"Identifikator fra Helsetjenesteenhetsregisteret\"/>\n" +
+            "                        </ns2:Ident>\n" +
             "                    </ns2:HealthcareProfessional>\n" +
             "                </ns2:Organisation>\n" +
             "            </ns2:Receiver>\n" +

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingNoHerIdXml.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingNoHerIdXml.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.testhelper.generator
 
-fun defaultFellesformatDialogmeldingEndreTidStedXmlRegex(): Regex {
+fun defaultFellesformatDialogmeldingNoHerIdXmlRegex(): Regex {
     return Regex(
         "<\\?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"\\?>\n" +
             "<EI_fellesformat xmlns=\"http://www.nav.no/xml/eiff/2/\" xmlns:ns6=\"http://www.kith.no/xmlstds/base64container\" xmlns:ns5=\"http://www.kith.no/xmlstds/felleskomponent1\" xmlns:ns2=\"http://www.kith.no/xmlstds/msghead/2006-05-24\" xmlns:ns4=\"http://www.kith.no/xmlstds/dialog/2006-10-11\" xmlns:ns3=\"http://www.w3.org/2000/09/xmldsig#\">\n" +
@@ -56,10 +56,6 @@ fun defaultFellesformatDialogmeldingEndreTidStedXmlRegex(): Regex {
             "                            <ns2:Id>9</ns2:Id>\n" +
             "                            <ns2:TypeId V=\"HPR\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"HPR-nummer\"/>\n" +
             "                        </ns2:Ident>\n" +
-            "                        <ns2:Ident>\n" +
-            "                            <ns2:Id>77</ns2:Id>\n" +
-            "                            <ns2:TypeId V=\"HER\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"Identifikator fra Helsetjenesteenhetsregisteret\"/>\n" +
-            "                        </ns2:Ident>\n" +
             "                    </ns2:HealthcareProfessional>\n" +
             "                </ns2:Organisation>\n" +
             "            </ns2:Receiver>\n" +
@@ -82,8 +78,8 @@ fun defaultFellesformatDialogmeldingEndreTidStedXmlRegex(): Regex {
             "                <ns2:Content>\n" +
             "                    <ns4:Dialogmelding>\n" +
             "                        <ns4:Foresporsel>\n" +
-            "                            <ns4:TypeForesp V=\"2\" S=\"2.16.578.1.12.4.1.1.8125\" DN=\"Endring dialogmøte 2\"/>\n" +
-            "                            <ns4:Sporsmal>Nytt tid og sted</ns4:Sporsmal>\n" +
+            "                            <ns4:TypeForesp V=\"1\" S=\"2.16.578.1.12.4.1.1.8125\" DN=\"Innkalling dialogmøte 2\"/>\n" +
+            "                            <ns4:Sporsmal>En tekst</ns4:Sporsmal>\n" +
             "                            <ns4:DokIdForesp>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}</ns4:DokIdForesp>\n" +
             "                        </ns4:Foresporsel>\n" +
             "                    </ns4:Dialogmelding>\n" +

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingReferatXml.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingReferatXml.kt
@@ -56,6 +56,10 @@ fun defaultFellesformatDialogmeldingReferatXmlRegex(): Regex {
             "                            <ns2:Id>9</ns2:Id>\n" +
             "                            <ns2:TypeId V=\"HPR\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"HPR-nummer\"/>\n" +
             "                        </ns2:Ident>\n" +
+            "                        <ns2:Ident>\n" +
+            "                            <ns2:Id>77</ns2:Id>\n" +
+            "                            <ns2:TypeId V=\"HER\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"Identifikator fra Helsetjenesteenhetsregisteret\"/>\n" +
+            "                        </ns2:Ident>\n" +
             "                    </ns2:HealthcareProfessional>\n" +
             "                </ns2:Organisation>\n" +
             "            </ns2:Receiver>\n" +

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingXml.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/FellesformatDialogmeldingXml.kt
@@ -56,6 +56,10 @@ fun defaultFellesformatDialogmeldingXmlRegex(): Regex {
             "                            <ns2:Id>9</ns2:Id>\n" +
             "                            <ns2:TypeId V=\"HPR\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"HPR-nummer\"/>\n" +
             "                        </ns2:Ident>\n" +
+            "                        <ns2:Ident>\n" +
+            "                            <ns2:Id>77</ns2:Id>\n" +
+            "                            <ns2:TypeId V=\"HER\" S=\"2.16.578.1.12.4.1.1.8116\" DN=\"Identifikator fra Helsetjenesteenhetsregisteret\"/>\n" +
+            "                        </ns2:Ident>\n" +
             "                    </ns2:HealthcareProfessional>\n" +
             "                </ns2:Organisation>\n" +
             "            </ns2:Receiver>\n" +


### PR DESCRIPTION
Legg til herId for behandler også, i de tilfellene vi har det (ca halvparten av behandlerene har herId).
Legg til herId i eksisterende FellesformatXmler, slik at tester ikke feiler.

Co-authored-by: June Henriksen <june.henriksen2@nav.no>