### PR TITLE
Accept all valid ident types

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/domain/Behandler.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/domain/Behandler.kt
@@ -56,11 +56,19 @@ fun Behandler.toPersonBehandlerDTO(
     telefon = this.telefon,
 )
 
+// Kodeverk 2.16.578.1.12.4.1.1.8116
 enum class BehandleridentType {
     FNR,
     HPR,
     HER,
     DNR,
+    HNR,
+    PNR,
+    SEF,
+    DKF,
+    SSN,
+    FPN,
+    XXX,
 }
 
 fun Behandler.hasAnId(): Boolean = personident != null || herId != null || hprId != null

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmeldingFromBehandlerGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmeldingFromBehandlerGenerator.kt
@@ -39,6 +39,26 @@ val fellesformatXMLHealthcareProfessional = """<?xml version="1.0" ?>
         <MottakenhetBlokk partnerReferanse="${UserConstants.PARTNERID}" />
     </EI_fellesformat>"""
 
+val fellesformatXMLHealthcareProfessionalMedIdenttypeAnnen = """<?xml version="1.0" ?>
+    <EI_fellesformat xmlns="http://www.nav.no/xml/eiff/2/" >
+    <MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24">
+        <HealthcareProfessional>
+            <Ident>
+                <Id>${UserConstants.FASTLEGE_FNR.value}</Id>
+                <TypeId V="${BehandleridentType.FNR}" S="2.16.578.1.12.4.1.1.8116" DN="Fødselsnummer Norsk fødselsnummer"/>
+            </Ident>
+            <Ident>
+                <Id>${UserConstants.OTHER_HPRID}</Id>
+                <TypeId V="${BehandleridentType.HPR}" S="2.16.578.1.12.4.1.1.8116" DN="HPR-nummer"/>
+            </Ident>
+            <Ident>
+                <Id>xyz</Id>
+                <TypeId V="${BehandleridentType.XXX}" S="2.16.578.1.12.4.1.1.8116" DN="Identifikator fra Helsetjenesteenhetsregisteret"/>
+            </Ident>
+        </HealthcareProfessional>
+        </MsgHead>
+        <MottakenhetBlokk partnerReferanse="${UserConstants.PARTNERID}" />
+    </EI_fellesformat>"""
 val fellesformatXmlWithIdenterWithoutPartnerId = """<?xml version="1.0" ?>
     <EI_fellesformat xmlns="http://www.nav.no/xml/eiff/2/" >
     <HealthcareProfessional>


### PR DESCRIPTION
Med dette slipper vi å få warnings av denne typen i loggen: 
Can't find behandleridenter in dialogmelding from behandler: navLogId: 2207270838sknl16325.1, msgId: c3a39ebf-a3ea-435a-9233-aedf008d90f0
