### PR TITLE
Sende oppfolgingsplan med tokenx

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -51,6 +51,9 @@ spec:
         - application: soknad-api
           namespace: aap
           cluster: dev-gcp
+        - application: syfooppfolgingsplanservice
+          namespace: team-esyfo
+          cluster: dev-fss
     outbound:
       external:
         - host: "syfopartnerinfo.dev-fss-pub.nais.io"
@@ -101,6 +104,8 @@ spec:
       value: QA.Q414.IU03_UTSENDING
     - name: AAP_SOKNAD_API_CLIENT_ID
       value: "dev-gcp:aap:soknad-api"
+    - name: SYFOOPPFOLGINGSPLANSERVICE_CLIENT_ID
+      value: "dev-fss:team-esyfo:syfooppfolgingsplanservice"
     - name: FASTLEGEREST_CLIENT_ID
       value: "dev-gcp.teamsykefravr.fastlegerest"
     - name: FASTLEGEREST_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -48,6 +48,9 @@ spec:
         - application: syfomodiaperson
           namespace: teamsykefravr
           cluster: prod-fss
+        - application: syfooppfolgingsplanservice
+          namespace: team-esyfo
+          cluster: prod-fss
     outbound:
       external:
         - host: "syfopartnerinfo.prod-fss-pub.nais.io"
@@ -98,6 +101,8 @@ spec:
       value: QA.P414.IU03_UTSENDING
     - name: AAP_SOKNAD_API_CLIENT_ID
       value: "prod-gcp:aap:soknad-api"
+    - name: SYFOOPPFOLGINGSPLANSERVICE_CLIENT_ID
+      value: "prod-fss:team-esyfo:syfooppfolgingsplanservice"
     - name: FASTLEGEREST_CLIENT_ID
       value: "prod-gcp.teamsykefravr.fastlegerest"
     - name: FASTLEGEREST_URL

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -52,7 +52,13 @@ fun main() {
         syfoPartnerinfoClientId = environment.syfoPartnerinfoClientId,
         syfoPartnerinfoUrl = environment.syfoPartnerinfoUrl,
     )
+    val pdlClient = PdlClient(
+        azureAdClient = azureAdClient,
+        pdlClientId = environment.pdlClientId,
+        pdlUrl = environment.pdlUrl,
+    )
     lateinit var behandlerService: BehandlerService
+    lateinit var dialogmeldingToBehandlerService: DialogmeldingToBehandlerService
 
     val applicationEngineEnvironment = applicationEngineEnvironment {
         log = logger
@@ -71,6 +77,10 @@ fun main() {
                 database = applicationDatabase,
                 environment.toggleSykmeldingbehandlere,
             )
+            dialogmeldingToBehandlerService = DialogmeldingToBehandlerService(
+                database = applicationDatabase,
+                pdlClient = pdlClient,
+            )
 
             apiModule(
                 applicationState = applicationState,
@@ -81,6 +91,7 @@ fun main() {
                 wellKnownInternalIdportenTokenX = wellKnownInternalIdportenTokenX,
                 azureAdClient = azureAdClient,
                 behandlerService = behandlerService,
+                dialogmeldingToBehandlerService = dialogmeldingToBehandlerService,
             )
         }
     }
@@ -88,15 +99,6 @@ fun main() {
     applicationEngineEnvironment.monitor.subscribe(ApplicationStarted) {
         applicationState.ready = true
         logger.info("Application is ready, running Java VM ${Runtime.version()}")
-        val pdlClient = PdlClient(
-            azureAdClient = azureAdClient,
-            pdlClientId = environment.pdlClientId,
-            pdlUrl = environment.pdlUrl,
-        )
-        val dialogmeldingToBehandlerService = DialogmeldingToBehandlerService(
-            database = applicationDatabase,
-            pdlClient = pdlClient,
-        )
         launchKafkaTaskDialogmeldingBestilling(
             applicationState = applicationState,
             applicationEnvironmentKafka = environment.kafka,

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -14,6 +14,10 @@ data class Environment(
     val personAPIAuthorizedConsumerClientIdList: List<String> = listOf(
         aapSoknadApiClientId,
     ),
+    val syfooppfolgingsplanserviceClientId: String = getEnvVar("SYFOOPPFOLGINGSPLANSERVICE_CLIENT_ID"),
+    val oppfolgingsplanAPIAuthorizedConsumerClientIdList: List<String> = listOf(
+        syfooppfolgingsplanserviceClientId,
+    ),
 
     val electorPath: String = getEnvVar("ELECTOR_PATH"),
     val serviceuserUsername: String = getEnvVar("SERVICEUSER_USERNAME"),

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -10,8 +10,10 @@ import no.nav.syfo.application.api.authentication.*
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.mq.MQSender
 import no.nav.syfo.behandler.BehandlerService
+import no.nav.syfo.behandler.DialogmeldingToBehandlerService
 import no.nav.syfo.behandler.api.person.access.PersonAPIConsumerAccessService
 import no.nav.syfo.behandler.api.person.registerPersonBehandlerApi
+import no.nav.syfo.behandler.api.person.registerPersonOppfolgingsplanApi
 import no.nav.syfo.behandler.api.registerBehandlerApi
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
@@ -26,6 +28,7 @@ fun Application.apiModule(
     wellKnownInternalIdportenTokenX: WellKnown,
     azureAdClient: AzureAdClient,
     behandlerService: BehandlerService,
+    dialogmeldingToBehandlerService: DialogmeldingToBehandlerService,
 ) {
     installMetrics()
     installContentNegotiation()
@@ -58,6 +61,9 @@ fun Application.apiModule(
     val personAPIConsumerAccessService = PersonAPIConsumerAccessService(
         authorizedConsumerApplicationClientIdList = environment.personAPIAuthorizedConsumerClientIdList,
     )
+    val oppfolgingsplanAPIConsumerAccessService = PersonAPIConsumerAccessService(
+        authorizedConsumerApplicationClientIdList = environment.oppfolgingsplanAPIAuthorizedConsumerClientIdList,
+    )
 
     routing {
         registerPodApi(
@@ -79,6 +85,12 @@ fun Application.apiModule(
             registerPersonBehandlerApi(
                 behandlerService = behandlerService,
                 personAPIConsumerAccessService = personAPIConsumerAccessService,
+            )
+            registerPersonOppfolgingsplanApi(
+                behandlerService = behandlerService,
+                dialogmeldingToBehandlerService = dialogmeldingToBehandlerService,
+                oppfolgingsplanService = oppfolgingsplanService,
+                oppfolgingsplanAPIConsumerAccessService = oppfolgingsplanAPIConsumerAccessService,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
@@ -67,7 +67,7 @@ class BehandlerService(
         }
     }
 
-    private suspend fun getFastlegeBehandler(
+    suspend fun getFastlegeBehandler(
         personident: Personident,
         token: String,
         callId: String,
@@ -79,18 +79,17 @@ class BehandlerService(
             callId = callId,
             systemRequest = systemRequest,
         )
-        if (fastlege != null && fastlege.hasAnId()) {
+        return if (fastlege != null && fastlege.hasAnId()) {
             val arbeidstaker = Arbeidstaker(
                 arbeidstakerPersonident = personident,
                 mottatt = OffsetDateTime.now(),
             )
-            return createOrGetBehandler(
+            createOrGetBehandler(
                 behandler = fastlege,
                 arbeidstaker = arbeidstaker,
                 relasjonstype = BehandlerArbeidstakerRelasjonstype.FASTLEGE,
             )
-        }
-        return null
+        } else null
     }
 
     suspend fun getAktivFastlegeBehandler(

--- a/src/main/kotlin/no/nav/syfo/behandler/api/person/PersonOppfolgingsplanApi.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/person/PersonOppfolgingsplanApi.kt
@@ -1,0 +1,72 @@
+package no.nav.syfo.behandler.api.person
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.syfo.application.api.authentication.personident
+import no.nav.syfo.behandler.BehandlerService
+import no.nav.syfo.behandler.DialogmeldingToBehandlerService
+import no.nav.syfo.behandler.api.person.access.PersonAPIConsumerAccessService
+import no.nav.syfo.oppfolgingsplan.OppfolgingsplanService
+import no.nav.syfo.oppfolgingsplan.domain.createRSHodemelding
+import no.nav.syfo.util.getBearerHeader
+import no.nav.syfo.util.getCallId
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
+
+const val personApiOppfolgingsplanPath = "/api/person/v1/oppfolgingsplan"
+
+fun Route.registerPersonOppfolgingsplanApi(
+    behandlerService: BehandlerService,
+    dialogmeldingToBehandlerService: DialogmeldingToBehandlerService,
+    oppfolgingsplanService: OppfolgingsplanService,
+    oppfolgingsplanAPIConsumerAccessService: PersonAPIConsumerAccessService,
+) {
+    route(personApiOppfolgingsplanPath) {
+        post() {
+            val callId = getCallId()
+            try {
+                val token = getBearerHeader()
+                    ?: throw IllegalArgumentException("No Authorization header supplied")
+                val requestPersonident = call.personident()
+                    ?: throw IllegalArgumentException("No Personident found in token")
+
+                oppfolgingsplanAPIConsumerAccessService.validateConsumerApplicationClientId(
+                    token = token,
+                )
+                val oppfolgingsplan = call.receive<RSOppfolgingsplan>()
+                if (requestPersonident.value != oppfolgingsplan.sykmeldtFnr) {
+                    throw IllegalArgumentException("Feil ved sending av oppfølgingsplan, ugyldig fnr")
+                }
+
+                val fastlegeBehandler = behandlerService.getFastlegeBehandler(
+                    personident = requestPersonident,
+                    token = token,
+                    callId = callId,
+                    systemRequest = true,
+                ) ?: throw IllegalArgumentException("Feil ved sending av oppfølgingsplan, FastlegeIkkeFunnet")
+
+                val arbeidstaker = dialogmeldingToBehandlerService.getArbeidstakerIfRelasjonToBehandler(
+                    behandlerRef = fastlegeBehandler.behandlerRef,
+                    personident = requestPersonident,
+                )
+
+                val melding = createRSHodemelding(
+                    behandler = fastlegeBehandler,
+                    arbeidstaker = arbeidstaker,
+                    oppfolgingsplan = oppfolgingsplan,
+                )
+                oppfolgingsplanService.sendMelding(melding)
+                call.respond(HttpStatusCode.OK)
+            } catch (e: IllegalArgumentException) {
+                val illegalArgumentMessage = "Could not send oppfolgingsplan to behandler"
+                log.warn("$illegalArgumentMessage: {}, {}", e.message, callId)
+                call.respond(HttpStatusCode.BadRequest, e.message ?: illegalArgumentMessage)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/behandler/api/person/RSOppfolgingsplan.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/person/RSOppfolgingsplan.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.behandler.api.person
+
+data class RSOppfolgingsplan(
+    val sykmeldtFnr: String,
+    val oppfolgingsplanPdf: ByteArray,
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/RSHodemelding.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/domain/RSHodemelding.kt
@@ -1,6 +1,58 @@
 package no.nav.syfo.oppfolgingsplan.domain
 
+import no.nav.syfo.behandler.api.person.RSOppfolgingsplan
+import no.nav.syfo.behandler.domain.Arbeidstaker
+import no.nav.syfo.behandler.domain.Behandler
+
 data class RSHodemelding(
     val meldingInfo: RSMeldingInfo?,
     val vedlegg: RSVedlegg?,
+)
+
+fun createRSHodemelding(
+    behandler: Behandler,
+    arbeidstaker: Arbeidstaker,
+    oppfolgingsplan: RSOppfolgingsplan,
+) = RSHodemelding(
+    meldingInfo = tilMeldingInfo(
+        mottaker = behandler.tilMottaker(),
+        pasient = arbeidstaker.tilPasient(),
+    ),
+    vedlegg = oppfolgingsplan.tilVedlegg(),
+)
+
+private fun tilMeldingInfo(
+    mottaker: RSMottaker,
+    pasient: RSPasient,
+) = RSMeldingInfo(
+    mottaker = mottaker,
+    pasient = pasient,
+)
+
+private fun Arbeidstaker.tilPasient() = RSPasient(
+    fnr = this.arbeidstakerPersonident.value,
+    fornavn = this.fornavn,
+    mellomnavn = this.mellomnavn,
+    etternavn = this.etternavn,
+)
+
+private fun RSOppfolgingsplan.tilVedlegg() = RSVedlegg(this.oppfolgingsplanPdf)
+
+private fun Behandler.tilMottaker() = RSMottaker(
+    partnerId = this.kontor.partnerId.toString(),
+    herId = this.kontor.herId?.toString(),
+    orgnummer = this.kontor.orgnummer?.value,
+    navn = this.kontor.navn,
+    adresse = this.kontor.adresse,
+    postnummer = this.kontor.postnummer,
+    poststed = this.kontor.poststed,
+    behandler = this.tilBehandler(),
+)
+
+private fun Behandler.tilBehandler() = RSBehandler(
+    fnr = this.personident?.value,
+    hprId = this.hprId,
+    fornavn = this.fornavn,
+    mellomnavn = this.mellomnavn,
+    etternavn = this.etternavn,
 )

--- a/src/test/kotlin/no/nav/syfo/behandler/api/person/PersonOppfolgingsplanApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandler/api/person/PersonOppfolgingsplanApiSpek.kt
@@ -1,0 +1,195 @@
+package no.nav.syfo.behandler.api.person
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import io.mockk.*
+import no.nav.syfo.application.mq.MQSender
+import no.nav.syfo.testhelper.*
+import no.nav.syfo.testhelper.generator.*
+import no.nav.syfo.util.bearerHeader
+import no.nav.syfo.util.configuredJacksonMapper
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class PersonOppfolgingsplanApiSpek : Spek({
+    val objectMapper: ObjectMapper = configuredJacksonMapper()
+    val mqSender = mockk<MQSender>()
+    justRun { mqSender.sendMessageToEmottak(any()) }
+
+    with(TestApplicationEngine()) {
+        start()
+
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+        application.testApiModule(
+            externalMockEnvironment = externalMockEnvironment,
+            mqSender = mqSender,
+        )
+
+        afterEachTest {
+            database.dropData()
+            clearMocks(mqSender)
+            justRun { mqSender.sendMessageToEmottak(any()) }
+        }
+
+        describe(PersonOppfolgingsplanApiSpek::class.java.simpleName) {
+            describe("Send oppfolgingsplan for person") {
+                val url = "$personApiOppfolgingsplanPath"
+                describe("Happy path") {
+                    it("Should send oppfolgingsplan") {
+                        val validToken = generateJWTIdporten(
+                            audience = externalMockEnvironment.environment.idportenTokenXClientId,
+                            clientId = externalMockEnvironment.environment.aapSoknadApiClientId,
+                            issuer = externalMockEnvironment.wellKnownInternalIdportenTokenX.issuer,
+                            pid = UserConstants.ARBEIDSTAKER_FNR.value,
+                        )
+
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                setBody(objectMapper.writeValueAsString(generateRSOppfolgingsplan()))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            verify(exactly = 1) { mqSender.sendMessageToEmottak(any()) }
+                        }
+                    }
+                }
+                describe("Unhappy paths") {
+                    it("Should not send oppfolgingsplan for other arbeidstaker") {
+                        val validToken = generateJWTIdporten(
+                            audience = externalMockEnvironment.environment.idportenTokenXClientId,
+                            clientId = externalMockEnvironment.environment.aapSoknadApiClientId,
+                            issuer = externalMockEnvironment.wellKnownInternalIdportenTokenX.issuer,
+                            pid = UserConstants.ARBEIDSTAKER_FNR.value,
+                        )
+
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                setBody(objectMapper.writeValueAsString(generateRSOppfolgingsplan(UserConstants.ARBEIDSTAKER_MED_FASTLEGE_MED_FLERE_PARTNERINFO)))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                            verify(exactly = 0) { mqSender.sendMessageToEmottak(any()) }
+                        }
+                    }
+                    it("should return error for arbeidstaker with no fastlege") {
+                        val validToken = generateJWTIdporten(
+                            audience = externalMockEnvironment.environment.idportenTokenXClientId,
+                            clientId = externalMockEnvironment.environment.aapSoknadApiClientId,
+                            issuer = externalMockEnvironment.wellKnownInternalIdportenTokenX.issuer,
+                            pid = UserConstants.ARBEIDSTAKER_UTEN_FASTLEGE_FNR.value,
+                        )
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                setBody(objectMapper.writeValueAsString(generateRSOppfolgingsplan(UserConstants.ARBEIDSTAKER_UTEN_FASTLEGE_FNR)))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                            verify(exactly = 0) { mqSender.sendMessageToEmottak(any()) }
+                        }
+                    }
+
+                    it("should return status Unauthorized if no token is supplied") {
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                setBody(objectMapper.writeValueAsString(generateRSOppfolgingsplan()))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
+                            verify(exactly = 0) { mqSender.sendMessageToEmottak(any()) }
+                        }
+                    }
+
+                    it("should return status BadRequest if no PID is supplied") {
+                        val tokenNoPid = generateJWTIdporten(
+                            audience = externalMockEnvironment.environment.idportenTokenXClientId,
+                            clientId = externalMockEnvironment.environment.aapSoknadApiClientId,
+                            issuer = externalMockEnvironment.wellKnownInternalIdportenTokenX.issuer,
+                            pid = null,
+                        )
+
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(tokenNoPid))
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                setBody(objectMapper.writeValueAsString(generateRSOppfolgingsplan()))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                            verify(exactly = 0) { mqSender.sendMessageToEmottak(any()) }
+                        }
+                    }
+
+                    it("should return status BadRequest if invalid Personident in PID is supplied") {
+                        val tokenInvalidPid = generateJWTIdporten(
+                            audience = externalMockEnvironment.environment.idportenTokenXClientId,
+                            clientId = externalMockEnvironment.environment.aapSoknadApiClientId,
+                            issuer = externalMockEnvironment.wellKnownInternalIdportenTokenX.issuer,
+                            pid = UserConstants.ARBEIDSTAKER_FNR.value.drop(1),
+                        )
+
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(tokenInvalidPid))
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                setBody(objectMapper.writeValueAsString(generateRSOppfolgingsplan()))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                            verify(exactly = 0) { mqSender.sendMessageToEmottak(any()) }
+                        }
+                    }
+
+                    it("should return status BadRequest if valid PID with and no ClientId is supplied") {
+                        val tokenValidPidNoClientId = generateJWTIdporten(
+                            audience = externalMockEnvironment.environment.idportenTokenXClientId,
+                            clientId = null,
+                            issuer = externalMockEnvironment.wellKnownInternalIdportenTokenX.issuer,
+                            pid = UserConstants.ARBEIDSTAKER_FNR.value,
+                        )
+
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(tokenValidPidNoClientId))
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                setBody(objectMapper.writeValueAsString(generateRSOppfolgingsplan()))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                            verify(exactly = 0) { mqSender.sendMessageToEmottak(any()) }
+                        }
+                    }
+
+                    it("should return status Forbiddden if valid PID with and unauthorized ClientId is supplied") {
+                        val tokenValidPidUnauthorizedClientId = generateJWTIdporten(
+                            audience = externalMockEnvironment.environment.idportenTokenXClientId,
+                            clientId = "app",
+                            issuer = externalMockEnvironment.wellKnownInternalIdportenTokenX.issuer,
+                            pid = UserConstants.ARBEIDSTAKER_FNR.value,
+                        )
+
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(tokenValidPidUnauthorizedClientId))
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                setBody(objectMapper.writeValueAsString(generateRSOppfolgingsplan()))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Forbidden
+                            verify(exactly = 0) { mqSender.sendMessageToEmottak(any()) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -3,13 +3,17 @@ package no.nav.syfo.testhelper
 import io.ktor.server.application.*
 import io.mockk.mockk
 import no.nav.syfo.application.api.apiModule
+import no.nav.syfo.application.mq.MQSender
 import no.nav.syfo.behandler.BehandlerService
+import no.nav.syfo.behandler.DialogmeldingToBehandlerService
 import no.nav.syfo.behandler.fastlege.FastlegeClient
 import no.nav.syfo.behandler.partnerinfo.PartnerinfoClient
 import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.pdl.PdlClient
 
 fun Application.testApiModule(
     externalMockEnvironment: ExternalMockEnvironment,
+    mqSender: MQSender = mockk(relaxed = true)
 ) {
     val azureAdClient = AzureAdClient(
         azureAppClientId = externalMockEnvironment.environment.aadAppClient,
@@ -20,7 +24,7 @@ fun Application.testApiModule(
         applicationState = externalMockEnvironment.applicationState,
         database = externalMockEnvironment.database,
         environment = externalMockEnvironment.environment,
-        mqSender = mockk(),
+        mqSender = mqSender,
         wellKnownInternalAzureAD = externalMockEnvironment.wellKnownInternalAzureAD,
         wellKnownInternalIdportenTokenX = externalMockEnvironment.wellKnownInternalIdportenTokenX,
         azureAdClient = azureAdClient,
@@ -37,6 +41,14 @@ fun Application.testApiModule(
             ),
             database = externalMockEnvironment.database,
             toggleSykmeldingbehandlere = externalMockEnvironment.environment.toggleSykmeldingbehandlere
-        )
+        ),
+        dialogmeldingToBehandlerService = DialogmeldingToBehandlerService(
+            database = externalMockEnvironment.database,
+            pdlClient = PdlClient(
+                azureAdClient = azureAdClient,
+                pdlClientId = externalMockEnvironment.environment.pdlClientId,
+                pdlUrl = externalMockEnvironment.environment.pdlUrl,
+            )
+        ),
     )
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -20,6 +20,8 @@ fun testEnvironment(
     idportenTokenXWellKnownUrl = "wellknown-idporten-tokenx",
     aapSoknadApiClientId = testAapSoknadApiClientId,
     personAPIAuthorizedConsumerClientIdList = listOf(testAapSoknadApiClientId),
+    syfooppfolgingsplanserviceClientId = testSyfooppfolgingsplanserviceClientId,
+    oppfolgingsplanAPIAuthorizedConsumerClientIdList = listOf(testAapSoknadApiClientId),
     electorPath = "/tmp",
     kafka = ApplicationEnvironmentKafka(
         aivenBootstrapServers = kafkaBootstrapServers,
@@ -55,6 +57,7 @@ fun testEnvironment(
 )
 
 const val testAapSoknadApiClientId = "soknad-api-client-id"
+const val testSyfooppfolgingsplanserviceClientId = "syfooppfolgingsplanservice-client-id"
 
 fun testAppState() = ApplicationState(
     alive = true,

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/RSOppfolgingsplanGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/RSOppfolgingsplanGenerator.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.testhelper.generator
+
+import no.nav.syfo.behandler.api.person.RSOppfolgingsplan
+import no.nav.syfo.domain.Personident
+import no.nav.syfo.testhelper.UserConstants
+
+fun generateRSOppfolgingsplan(
+    arbeidstakerPersonIdent: Personident = UserConstants.ARBEIDSTAKER_FNR,
+): RSOppfolgingsplan {
+    return RSOppfolgingsplan(
+        sykmeldtFnr = arbeidstakerPersonIdent.value,
+        oppfolgingsplanPdf = byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+    )
+}


### PR DESCRIPTION
Denne PR'en har nytt api for å sende oppfølgingsplan med tokenx. Tar den tilsvarende tjenesten med system-token i en egen PR.