### PR TITLE
Replace colon in search

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
@@ -55,10 +55,14 @@ class BehandlerService(
         searchStrings: String,
     ): List<Behandler> {
         val tokens = searchStrings.split(" ")
-            .filter { s -> !s.isBlank() }
-            .map { s -> s.replace(",", "") }
-            .map { s -> s.replace(".", "") }
-            .map { s -> s.trim() }
+            .filter { s -> s.isNotBlank() }
+            .map { s ->
+                s
+                    .replace(",", "")
+                    .replace(".", "")
+                    .replace(":", "")
+                    .trim()
+            }
             .filter { s -> s.length > 2 }
         return database.searchBehandler(
             searchStrings = tokens,


### PR DESCRIPTION
Søkestrengen i frontend kan bli oppdatert til å inneholde kolon idet man velger en behandler. Formatet er da "etternavn, fornavn: kontor", og søket vil kun slå ut på kontor. Ved å fjerne kolon fra stringen vil vi da få søkt på hele navnet. I tillegg så chaines replace-kallene, i stedet for å ha mange maps.