### PR TITLE
Use transaction isolation level READ_COMMITTED

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/database/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/application/database/Database.kt
@@ -28,7 +28,7 @@ class Database(
             maximumPoolSize = config.poolSize
             minimumIdle = 1
             isAutoCommit = false
-            transactionIsolation = "TRANSACTION_READ_COMMITED"
+            transactionIsolation = "TRANSACTION_READ_COMMITTED"
             metricsTrackerFactory = PrometheusMetricsTrackerFactory()
             validate()
         }

--- a/src/main/kotlin/no/nav/syfo/application/database/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/application/database/Database.kt
@@ -28,7 +28,7 @@ class Database(
             maximumPoolSize = config.poolSize
             minimumIdle = 1
             isAutoCommit = false
-            transactionIsolation = "TRANSACTION_REPEATABLE_READ"
+            transactionIsolation = "TRANSACTION_READ_COMMITED"
             metricsTrackerFactory = PrometheusMetricsTrackerFactory()
             validate()
         }


### PR DESCRIPTION
Foreslår at vi prøver ut dette i en app for å løse problemet med sporadiske feil mot databasen av denne typen: org.postgresql.util.PSQLException: ERROR: could not serialize access due to concurrent update