### PR TITLE
IS-1837: Manuell oppdatering av to kontor og tilhørende behandlere

### DIFF
--- a/src/main/resources/db/migration/V3_9__update_behandler_kontor.sql
+++ b/src/main/resources/db/migration/V3_9__update_behandler_kontor.sql
@@ -1,0 +1,40 @@
+UPDATE BEHANDLER_KONTOR SET
+her_id='172431',
+navn='GAMLE KRAGERØVEI LEGESENTER',
+orgnummer='929846923',
+dialogmelding_enabled=now(),
+dialogmelding_enabled_locked=false,
+updated_at=now()
+WHERE ID=803;
+
+UPDATE BEHANDLER SET invalidated=now() where id=5848;
+UPDATE BEHANDLER SET invalidated=now() where id=11301;
+UPDATE BEHANDLER SET invalidated=now() where id=19562;
+UPDATE BEHANDLER SET invalidated=now() where id=21530;
+UPDATE BEHANDLER SET invalidated=now() where id=23706;
+UPDATE BEHANDLER SET invalidated=now() where id=24390;
+UPDATE BEHANDLER SET invalidated=now() where id=24646;
+UPDATE BEHANDLER SET invalidated=now() where id=25862;
+UPDATE BEHANDLER SET invalidated=now() where id=29992;
+
+UPDATE BEHANDLER SET her_id='172463' where id=2490;
+UPDATE BEHANDLER SET her_id='172464' where id=798;
+UPDATE BEHANDLER SET her_id='172940' where id=22306;
+UPDATE BEHANDLER SET her_id='172466' where id=4594;
+
+UPDATE BEHANDLER_KONTOR SET
+her_id='172135',
+navn='KVERNEVIK LEGEKONTOR',
+orgnummer='930010081',
+dialogmelding_enabled=now(),
+dialogmelding_enabled_locked=false,
+updated_at=now()
+WHERE ID=488;
+
+UPDATE BEHANDLER SET invalidated=now() where id=1931;
+UPDATE BEHANDLER SET invalidated=now() where id=578;
+UPDATE BEHANDLER SET invalidated=now() where id=4383;
+UPDATE BEHANDLER SET invalidated=now() where id=5758;
+UPDATE BEHANDLER SET invalidated=now() where id=6808;
+UPDATE BEHANDLER SET invalidated=now() where id=11137;
+UPDATE BEHANDLER SET invalidated=now() where id=21407;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi har hatt problemer med dialogmeldinger som ikke har kommet fram til konkrete behandlere. Har omsider fått avdekket at problemet skyldes at vi har feil her_id på to kontor, dvs feil i relasjon til partnerId'en. Det betyr at meldingene vi har sendt har blitt "feiladressert". 

Oppdaterer samtidig behandlerlistene for disse kontorene slik at de samsvarer med adresseregisteret: invaliderer de som ikke lengre er med, og oppdaterer behandler-herId der de er feil.

Jeg mistenker at slike feil kan oppstå i forbindelse med flytting/reorganisering/splitting av legekontor.

Den mer langsiktige løsningen på dette problemet vil være å slutte å bruke partnerId'er i denne miksen, men da må vi først få tilgang til en ny tjeneste hos e-mottak for å verifisere kontor-herId'er.