### PR TITLE
IS-1913: Replace partnerID for HP kontor

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmelding/converter/MottakenhetBlokkConverter.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmelding/converter/MottakenhetBlokkConverter.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.dialogmelding.converter
 
 import no.nav.syfo.dialogmelding.bestilling.domain.*
+import no.nav.syfo.domain.PartnerId
 import no.nav.xml.eiff._2.ObjectFactory
 import no.nav.xml.eiff._2.XMLMottakenhetBlokk
 
@@ -8,8 +9,10 @@ fun createMottakenhetBlokk(
     melding: DialogmeldingToBehandlerBestilling,
 ): XMLMottakenhetBlokk {
     val factory = ObjectFactory()
+    val storedPartnerId = melding.behandler.kontor.partnerId
+    val partnerId = if (storedPartnerId.value == 14859 || storedPartnerId.value == 41578) PartnerId(60274) else storedPartnerId
     return factory.createXMLMottakenhetBlokk()
-        .withPartnerReferanse(melding.behandler.kontor.partnerId.toString())
+        .withPartnerReferanse(partnerId.toString())
         .withEbRole("Saksbehandler")
         .withEbService(
             when (Pair(melding.type, melding.kodeverk)) {

--- a/src/test/kotlin/no/nav/syfo/dialogmelding/converter/FellesformatConverterSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmelding/converter/FellesformatConverterSpek.kt
@@ -34,11 +34,60 @@ class FellesformatConverterSpek : Spek({
                 expectedFellesformatMessageAsRegex.matches(actualFellesformat.message!!),
             )
         }
+
+        it("create XMLEIFellesformat with replaced partnerId for kontor with parnerId 14859") {
+            val storedPartnerId = 14859
+            val wantedPartnerId = 60274
+            val melding = createDialogmeldingToBehandlerBestilling(
+                arbeidstakerPersonident = arbeidstakerPersonident,
+                PartnerId(storedPartnerId),
+                herId = null,
+            )
+
+            val arbeidstaker = generateArbeidstaker(arbeidstakerPersonident)
+            val expectedFellesformatMessageAsRegex = defaultFellesformatDialogmeldingNoHerIdXmlRegex().pattern
+                .replace("partnerReferanse=\"1\"", "partnerReferanse=\"${wantedPartnerId}\"").toRegex()
+
+            val actualXMLEIFellesformat = createFellesformat(
+                melding,
+                arbeidstaker,
+            )
+            val actualFellesformat = Fellesformat(actualXMLEIFellesformat, JAXB::marshallDialogmelding1_0)
+
+            assertTrue(
+                expectedFellesformatMessageAsRegex.matches(actualFellesformat.message!!),
+            )
+        }
+
+        it("create XMLEIFellesformat with replaced partnerId for kontor with parnerId 41578") {
+            val storedPartnerId = 41578
+            val wantedPartnerId = 60274
+            val melding = createDialogmeldingToBehandlerBestilling(
+                arbeidstakerPersonident = arbeidstakerPersonident,
+                PartnerId(storedPartnerId),
+                herId = null,
+            )
+
+            val arbeidstaker = generateArbeidstaker(arbeidstakerPersonident)
+            val expectedFellesformatMessageAsRegex = defaultFellesformatDialogmeldingNoHerIdXmlRegex().pattern
+                .replace("partnerReferanse=\"1\"", "partnerReferanse=\"${wantedPartnerId}\"").toRegex()
+
+            val actualXMLEIFellesformat = createFellesformat(
+                melding,
+                arbeidstaker,
+            )
+            val actualFellesformat = Fellesformat(actualXMLEIFellesformat, JAXB::marshallDialogmelding1_0)
+
+            assertTrue(
+                expectedFellesformatMessageAsRegex.matches(actualFellesformat.message!!),
+            )
+        }
     }
 })
 
 fun createDialogmeldingToBehandlerBestilling(
     arbeidstakerPersonident: Personident,
+    partnerId: PartnerId = PartnerId(1),
     herId: Int? = 77,
 ): DialogmeldingToBehandlerBestilling {
     val behandlerRef = UUID.randomUUID()
@@ -50,7 +99,7 @@ fun createDialogmeldingToBehandlerBestilling(
     ).toDialogmeldingToBehandlerBestilling(
         behandler = generateBehandler(
             behandlerRef = behandlerRef,
-            partnerId = PartnerId(1),
+            partnerId = partnerId,
             herId = herId,
         ),
     )


### PR DESCRIPTION
These partnerIDs have been wrong since the kontor changed to Helseplattformen, so meldinger have been sent to a disabled Helsenett inbox.
Now we change the partnerID before sending the melding to emottak, so they can route the message correctly.
Use hard coded id's because we don't expect them to change soon, and no more kontor will be added soon.