### PR TITLE
IS-1918: Resend messages to HP that failed

### DIFF
--- a/src/main/resources/db/migration/V5_2__resend_failed_messages.sql
+++ b/src/main/resources/db/migration/V5_2__resend_failed_messages.sql
@@ -1,0 +1,18 @@
+UPDATE behandler_dialogmelding_bestilling
+SET sendt = null
+WHERE uuid IN ('8d6b9608-3cb3-4947-8e8f-92b9603050aa',
+               '633e95cb-3426-493d-82d0-8aa20d1c3383',
+               '85bfb9b2-c654-4931-9cda-5d90cc307b5b',
+               '71791373-d0f1-4e4d-8fda-68424b563636',
+               '0001e53e-8433-46ae-920a-6d0e30bbc3cf',
+               '29231f58-868d-450d-b3fd-da300dae6579',
+               '1610f031-d620-4a99-ac49-540844db6f8e',
+               '7ab0a905-660c-492c-8bc2-093d05e164e4',
+               '685c2f59-2468-413f-8ae3-8db98419fe49',
+               '64ca82e7-8d4c-4c3d-bf2c-4e0e910f3b67',
+               '1438c1de-6d9b-47f9-94b5-42494f8b5ffd',
+               '44c3e9d8-5857-4ee7-a317-04a9f915b1fa',
+               '8bf2337e-391d-422c-8be2-05afdab448eb',
+               '76ca4a8b-30b6-4344-b71e-a889b03aca2e',
+               '69954c2a-0a9b-4d47-8871-0328370a06e0',
+               '48e056ee-09f8-47c3-9322-4c3e7783a3d6');


### PR DESCRIPTION
This resends messages from two kontor sent on or after 1 dec.
List of uuids was manually fetched from DB based on messages sent to behandlere on the two kontor.

See also:
IS-193: https://github.com/navikt/isdialogmelding/pull/274
IS-1917: https://github.com/navikt/isdialogmelding/pull/275