### PR TITLE
Authorize lps-oppfolgingsplan-mottak to access OppfolgingsplanSystemApi

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -21,8 +21,10 @@ data class Environment(
         syfooppfolgingsplanserviceClientId,
     ),
     private val syfooppfolgingsplanserviceApplicationName: String = "syfooppfolgingsplanservice",
+    private val lpsOppfolgingsplanMottakApplicationName: String = "lps-oppfolgingsplan-mottak",
     val oppfolgingsplanSystemAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
         syfooppfolgingsplanserviceApplicationName,
+        lpsOppfolgingsplanMottakApplicationName,
     ),
 
     val electorPath: String = getEnvVar("ELECTOR_PATH"),


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Gi lps-oppfolgingsplan-mottak tillatelse til å aksessere OppfolgingsplanSystemApi

### Hva er nytt / hva har blitt fikset?
lps-oppfolgingsplan-mottak kan nå gjøre POST kall mot `.../api/v2/send/oppfolgingsplan`
for å sende Altinn-LPS til fastlege.