### PR TITLE
IS-1906: Disabler duplikate behandlerkontor, og legger inn manglende herId på noen behandlere

### DIFF
--- a/src/main/resources/db/migration/V5_5__disable_behandler_kontor.sql
+++ b/src/main/resources/db/migration/V5_5__disable_behandler_kontor.sql
@@ -1,0 +1,11 @@
+UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=null,dialogmelding_enabled_locked=true WHERE ID=936;
+UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=null,dialogmelding_enabled_locked=true WHERE ID=209;
+UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=null,dialogmelding_enabled_locked=true WHERE ID=222;
+UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=null,dialogmelding_enabled_locked=true WHERE ID=1234;
+UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=null,dialogmelding_enabled_locked=true WHERE ID=503;
+UPDATE BEHANDLER SET her_id='159749' where id=23009;
+UPDATE BEHANDLER SET her_id='177974' where id=31244;
+UPDATE BEHANDLER SET her_id='178768' where id=33079;
+UPDATE BEHANDLER SET her_id='86655' where id=36753;
+
+


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Når kontor bytter EPJ-system får de ny partnerId, og da oppretter vi et kontor som blir duplikat med det gamle. Disabler noen av de forekomstene som logges nå. Har sjekket at behandlerne er de samme, og at dialogmeldingene fungerer som de skal på den gjenværende kontor-forekomsten.

Det virker som meldinger sendt til de gamle kontorene/partnerId'ene feiler uten av vi får negativ apprec (får ikke apprec i det hele tatt).