### PR TITLE
IS-1821: Disable cronjob for now

### DIFF
--- a/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
@@ -57,7 +57,7 @@ fun cronjobModule(
         dialogmeldingStatusCronjob,
         verifyPartnerIdCronjob,
         suspensjonCronjob,
-        verifyBehandlereForKontorCronjob,
+        // verifyBehandlereForKontorCronjob,
     ).forEach {
         launchBackgroundTask(
             applicationState = applicationState,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Har fått invalidert mange behandlere (over 5000 forekomster) som var deaktivert i adresseregisteret.

Lager fortsatt en del følgefeil (særlig i fastlegerest og syfohelsenettproxy), så deaktiverer inntil vi har noe nytt for den å gjøre.