### PR TITLE
IS-1946: Invalider kontor og tilhørende behandlere

### DIFF
--- a/src/main/resources/db/migration/V6_2__disable_behandler_kontor.sql
+++ b/src/main/resources/db/migration/V6_2__disable_behandler_kontor.sql
@@ -1,0 +1,2 @@
+UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=null WHERE ID=1926;
+UPDATE BEHANDLER SET invalidated=now(),updated_at=now() WHERE kontor_id=1926;

--- a/src/main/resources/db/migration/V6_2__disable_behandler_kontor.sql
+++ b/src/main/resources/db/migration/V6_2__disable_behandler_kontor.sql
@@ -1,2 +1,5 @@
 UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=null WHERE ID=1926;
 UPDATE BEHANDLER SET invalidated=now(),updated_at=now() WHERE kontor_id=1926;
+
+UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=null,dialogmelding_enabled_locked=true WHERE ID=1501;
+UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=null,dialogmelding_enabled_locked=true WHERE ID=2103;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fått en beskjed fra e-mottak om et kontor som ikke kan motta dialogmeldinger lengre.

Kontoret med id 1926 er fortsatt aktivt, men har ingen behandlere i Adresseregisteret.
Kontorene med id 1501 og 2103 er deaktivterte i Adresseregisteret.