### PR TITLE
IS-2732: Oppdatere fra DNR til FNR fra Adresseregisteret

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
@@ -288,6 +288,10 @@ class BehandlerService(
         database.updateBehandlerIdenter(behandlerRef, identer)
     }
 
+    fun updateBehandlerPersonident(behandlerRef: UUID, personident: String) {
+        database.updateBehandlerPersonident(behandlerRef, personident)
+    }
+
     fun updateBehandlerNavnAndKategoriAndHerId(
         behandlerRef: UUID,
         fornavn: String,

--- a/src/main/kotlin/no/nav/syfo/behandler/database/BehandlerQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/database/BehandlerQuery.kt
@@ -262,6 +262,27 @@ fun DatabaseInterface.updateBehandlerIdenter(behandlerRef: UUID, identer: Map<Be
     }
 }
 
+const val queryUpdateBehandlerPersonident =
+    """
+        UPDATE BEHANDLER
+        SET personident = ?,
+        updated_at = ?
+        WHERE behandler_ref=?
+    """
+
+fun DatabaseInterface.updateBehandlerPersonident(behandlerRef: UUID, personident: String) {
+    this.connection.use { connection ->
+        connection.prepareStatement(queryUpdateBehandlerPersonident)
+            .use {
+                it.setString(1, personident)
+                it.setObject(2, OffsetDateTime.now())
+                it.setString(3, behandlerRef.toString())
+                it.executeUpdate()
+            }
+        connection.commit()
+    }
+}
+
 const val queryInvalidateBehandler =
     """
         UPDATE BEHANDLER

--- a/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobSpek.kt
@@ -234,6 +234,30 @@ class VerifyBehandlereForKontorCronjobSpek : Spek({
                     pBehandlerAfter!!.herId shouldBeEqualTo HERID.toString()
                     pBehandlerAfter!!.kategori shouldBeEqualTo BehandlerKategori.TANNLEGE.name
                 }
+                it("Cronjob oppdaterer eksisterende behandler med DNR der forekomsten i Adresseregisteret har FNR") {
+                    val kontorId = createKontor(HERID_KONTOR_OK)
+                    val pBehandler = createBehandler(
+                        kontorId = kontorId,
+                        hprId = HPRID,
+                        personident = FASTLEGE_DNR,
+                        fornavn = "for",
+                        etternavn = "etter",
+                        kategori = BehandlerKategori.LEGE,
+                    )
+                    runBlocking {
+                        cronJob.verifyBehandlereForKontorJob()
+                    }
+                    val behandlerAfter = database.getBehandlereForKontor(kontorId)
+                    behandlerAfter.size shouldBeEqualTo 2
+                    val pBehandlerAfter = behandlerAfter.firstOrNull { it.hprId == HPRID.toString() }
+                    pBehandlerAfter!!.id shouldBeEqualTo pBehandler.id
+                    pBehandlerAfter!!.personident shouldBeEqualTo FASTLEGE_FNR.value
+                    pBehandlerAfter!!.behandlerRef shouldBeEqualTo pBehandler.behandlerRef
+                    pBehandlerAfter!!.fornavn shouldBeEqualTo BEHANDLER_FORNAVN
+                    pBehandlerAfter!!.etternavn shouldBeEqualTo BEHANDLER_ETTERNAVN
+                    pBehandlerAfter!!.herId shouldBeEqualTo HERID.toString()
+                    pBehandlerAfter!!.kategori shouldBeEqualTo BehandlerKategori.LEGE.name
+                }
                 it("Cronjob legger til ny behandler og invaliderer eksisterende") {
                     val kontorId = createKontor(HERID_KONTOR_OK)
                     val pBehandler = createBehandler(kontorId)


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Få oppdatert et antall behandlere i vårt behandlerregister som har DNR, mens de har fått FNR i Adresseregisteret. Det er normalt at personer bytter til ordinært FNR etter å ha hatt DNR noen år.