### PR TITLE
IS-2732: Oppdatere spesifikk behandler fra Adresseregisteret

### DIFF
--- a/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.cronjob.leaderelection.LeaderPodClient
 import no.nav.syfo.dialogmelding.DialogmeldingService
 import no.nav.syfo.dialogmelding.cronjob.DialogmeldingStatusCronjob
 import no.nav.syfo.dialogmelding.status.DialogmeldingStatusService
+import java.util.UUID
 
 fun cronjobModule(
     applicationState: ApplicationState,
@@ -53,6 +54,7 @@ fun cronjobModule(
         behandlerService = behandlerService,
         fastlegeClient = fastlegeClient,
         syfohelsenettproxyClient = syfohelsenettproxyClient,
+        behandlerToBeUpdated = listOf(UUID.fromString("3f5c938d-b16a-4474-a294-9e121e7efd17"))
     )
 
     listOf(

--- a/src/main/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjob.kt
@@ -25,6 +25,7 @@ class VerifyBehandlereForKontorCronjob(
     val behandlerService: BehandlerService,
     val fastlegeClient: FastlegeClient,
     val syfohelsenettproxyClient: SyfohelsenettproxyClient,
+    val behandlerToBeUpdated: List<UUID> = emptyList(),
 ) : DialogmeldingCronjob {
     private val runAtHour = 6
     private val runDay = DayOfWeek.SUNDAY
@@ -334,7 +335,5 @@ class VerifyBehandlereForKontorCronjob(
 
     companion object {
         private val log = LoggerFactory.getLogger(VerifyBehandlereForKontorCronjob::class.java)
-
-        private val behandlerToBeUpdated = listOf(UUID.fromString("3f5c938d-b16a-4474-a294-9e121e7efd17"))
     }
 }

--- a/src/main/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjob.kt
@@ -304,8 +304,10 @@ class VerifyBehandlereForKontorCronjob(
                     val hprPersonident = Personident(hprBehandlerFnr)
                     val existingPersonIdent = existingBehandler.personident?.let { Personident(it) }
 
-                    val doUpdatePersonident = existingPersonIdent == null || existingPersonIdent.isDnrMatchingFnr(hprPersonident)
-                    // TODO: handle remaining case: personident changed, but not DNR from before
+                    val doUpdatePersonident = existingPersonIdent == null ||
+                        existingPersonIdent.isDnrMatchingFnr(hprPersonident) ||
+                        behandlerToBeUpdated.contains(existingBehandler.behandlerRef)
+
                     if (doUpdatePersonident) {
                         behandlerService.updateBehandlerPersonident(
                             behandlerRef = existingBehandler.behandlerRef,
@@ -332,5 +334,7 @@ class VerifyBehandlereForKontorCronjob(
 
     companion object {
         private val log = LoggerFactory.getLogger(VerifyBehandlereForKontorCronjob::class.java)
+
+        private val behandlerToBeUpdated = listOf(UUID.fromString("3f5c938d-b16a-4474-a294-9e121e7efd17"))
     }
 }

--- a/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobSpek.kt
@@ -17,7 +17,6 @@ import no.nav.syfo.domain.Personident
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.BEHANDLER_ETTERNAVN
 import no.nav.syfo.testhelper.UserConstants.BEHANDLER_FORNAVN
-import no.nav.syfo.testhelper.UserConstants.FASTLEGE_ANNEN_FNR
 import no.nav.syfo.testhelper.UserConstants.FASTLEGE_DNR
 import no.nav.syfo.testhelper.UserConstants.FASTLEGE_FNR
 import no.nav.syfo.testhelper.UserConstants.FASTLEGE_TREDJE_FNR
@@ -77,10 +76,12 @@ class VerifyBehandlereForKontorCronjobSpek : Spek({
                 ),
                 database = database,
             )
+            val behandlerToBeUpdated = UUID.randomUUID()
             val cronJob = VerifyBehandlereForKontorCronjob(
                 behandlerService = behandlerService,
                 fastlegeClient = fastlegeClient,
                 syfohelsenettproxyClient = syfohelsenettproxyClient,
+                behandlerToBeUpdated = listOf(behandlerToBeUpdated),
             )
             beforeEachTest {
                 database.dropData()
@@ -263,7 +264,7 @@ class VerifyBehandlereForKontorCronjobSpek : Spek({
                 it("Cronjob oppdaterer spesifikk behandler") {
                     val kontorId = createKontor(HERID_KONTOR_OK)
                     val pBehandler = createBehandler(
-                        behandlerRef = UUID.fromString("3f5c938d-b16a-4474-a294-9e121e7efd17"),
+                        behandlerRef = behandlerToBeUpdated,
                         kontorId = kontorId,
                         hprId = HPRID,
                         personident = FASTLEGE_TREDJE_FNR,

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -46,6 +46,7 @@ object UserConstants {
     val FASTLEGE_FNR_SUSPENDERT = Personident("12125678912")
     val FASTLEGE_DNR = Personident("52125678911")
     val FASTLEGE_ANNEN_FNR = Personident(FASTLEGE_FNR.value.replace("2", "4"))
+    val FASTLEGE_TREDJE_FNR = Personident(FASTLEGE_FNR.value.replace("2", "5"))
     val FASTLEGE_UTEN_KATEGORI_FNR = Personident(FASTLEGE_FNR.value.replace("2", "5"))
 
     val BEHANDLER_FORNAVN = "Behandler"


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi har en behandler som har byttet fnr (og ikke fra dnr). Vil ikke skje så ofte, så det enkleste er å instruere cronjob'en om å oppdatere akkurat denne behandleren (dvs med spesifikk behandlerRef) fra Adresseregisteret.