### PR TITLE
give followupplan-backend inbound access

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -52,6 +52,9 @@ spec:
         - application: lps-oppfolgingsplan-mottak
           namespace: team-esyfo
           cluster: dev-gcp
+        - application: followupplan-backend
+          namespace: team-esyfo
+          cluster: dev-gcp
         - application: oppslag
           namespace: aap
           cluster: dev-gcp
@@ -123,6 +126,8 @@ spec:
       value: "dev-gcp:aap:oppslag"
     - name: SYFOOPPFOLGINGSPLANSERVICE_CLIENT_ID
       value: "dev-fss:team-esyfo:syfooppfolgingsplanservice"
+    - name: FOLLOWUPPLAN_BACKEND_CLIENT_ID
+      value: "dev-gcp:team-esyfo:followupplan-backend"
     - name: FASTLEGEREST_CLIENT_ID
       value: "dev-gcp.teamsykefravr.fastlegerest"
     - name: FASTLEGEREST_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -52,6 +52,9 @@ spec:
         - application: lps-oppfolgingsplan-mottak
           namespace: team-esyfo
           cluster: prod-gcp
+        - application: followupplan-backend
+          namespace: team-esyfo
+          cluster: dev-gcp
         - application: oppslag
           namespace: aap
           cluster: prod-gcp
@@ -123,6 +126,8 @@ spec:
       value: "prod-gcp:aap:oppslag"
     - name: SYFOOPPFOLGINGSPLANSERVICE_CLIENT_ID
       value: "prod-fss:team-esyfo:syfooppfolgingsplanservice"
+    - name: FOLLOWUPPLAN_BACKEND_CLIENT_ID
+      value: "prod-gcp:team-esyfo:followupplan-backend"
     - name: FASTLEGEREST_CLIENT_ID
       value: "prod-gcp.teamsykefravr.fastlegerest"
     - name: FASTLEGEREST_URL

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -19,8 +19,10 @@ data class Environment(
         aapOppslagClientId,
     ),
     val syfooppfolgingsplanserviceClientId: String = getEnvVar("SYFOOPPFOLGINGSPLANSERVICE_CLIENT_ID"),
+    val followupplanBackendClientId: String = getEnvVar("FOLLOWUPPLAN_BACKEND_CLIENT_ID"),
     val oppfolgingsplanAPIAuthorizedConsumerClientIdList: List<String> = listOf(
         syfooppfolgingsplanserviceClientId,
+        followupplanBackendClientId,
     ),
     private val syfooppfolgingsplanserviceApplicationName: String = "syfooppfolgingsplanservice",
     private val lpsOppfolgingsplanMottakApplicationName: String = "lps-oppfolgingsplan-mottak",


### PR DESCRIPTION
[Followupplan-backend](https://github.com/navikt/followupplan-backend) er den nye backenden til oppfølgingsplanen på nav.no. Den skal på sikt erstatte syfooppfolgingsplanservice, og trenger derfor tilgang til isdialogmelding for å vidresende plan til fastlege.