### PR TITLE
Disable legevaktkontor

### DIFF
--- a/src/main/resources/db/migration/V7_35__lock_legevakt_kontor.sql
+++ b/src/main/resources/db/migration/V7_35__lock_legevakt_kontor.sql
@@ -1,0 +1,5 @@
+UPDATE BEHANDLER_KONTOR SET
+dialogmelding_enabled=null,
+dialogmelding_enabled_locked=true,
+updated_at=now()
+WHERE her_id='87796' and partner_id='217';


### PR DESCRIPTION
Det har blitt to duplikater av dette kontoret siden det tydeligvis har fått ny partnerId - det gamle var disabled fra før.