### PR TITLE
IS-3883: Oppdater kontornavn fra Adresseregisteret

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
@@ -188,7 +188,7 @@ class BehandlerService(
             if (pBehandlerKontor == null) {
                 connection.createBehandlerKontor(behandlerKontor)
             } else {
-                connection.updateBehandlerKontorSystemAndAdresse(behandlerKontor, pBehandlerKontor)
+                connection.updateBehandlerKontorSystemAndAdresseAndNavn(behandlerKontor, pBehandlerKontor)
             }
             connection.commit()
         }
@@ -362,7 +362,7 @@ class BehandlerService(
         database.connection.use { connection ->
             val pBehandlerKontor = connection.getBehandlerKontor(behandler.kontor.partnerId)
             val kontorId = if (pBehandlerKontor != null) {
-                connection.updateBehandlerKontorSystemAndAdresse(
+                connection.updateBehandlerKontorSystemAndAdresseAndNavn(
                     behandlerKontor = behandler.kontor,
                     existingBehandlerKontor = pBehandlerKontor,
                 )
@@ -400,7 +400,7 @@ class BehandlerService(
                 COUNT_BEHANDLER_UPDATED.increment()
             }
             val existingBehandlerKontor = connection.getBehandlerKontor(behandler.kontor.partnerId)!!
-            connection.updateBehandlerKontorSystemAndAdresse(
+            connection.updateBehandlerKontorSystemAndAdresseAndNavn(
                 behandlerKontor = behandler.kontor,
                 existingBehandlerKontor = existingBehandlerKontor,
                 existingBehandler = existingBehandler,
@@ -409,28 +409,36 @@ class BehandlerService(
         }
     }
 
-    fun updateBehandlerKontorSystemAndAdresse(
+    fun updateBehandlerKontorSystemAndAdresseAndNavn(
         behandlerKontor: BehandlerKontor,
+        shouldUpdateKontorNavn: Boolean = false,
     ) {
         database.connection.use { connection ->
             connection.getBehandlerKontor(behandlerKontor.partnerId)?.let { existingBehandlerKontor ->
-                connection.updateBehandlerKontorSystemAndAdresse(behandlerKontor, existingBehandlerKontor)
+                connection.updateBehandlerKontorSystemAndAdresseAndNavn(
+                    behandlerKontor = behandlerKontor,
+                    existingBehandlerKontor = existingBehandlerKontor,
+                    shouldUpdateKontorNavn = shouldUpdateKontorNavn,
+                )
             }
             connection.commit()
         }
     }
 
-    private fun Connection.updateBehandlerKontorSystemAndAdresse(
+    private fun Connection.updateBehandlerKontorSystemAndAdresseAndNavn(
         behandlerKontor: BehandlerKontor,
         existingBehandlerKontor: PBehandlerKontor,
         existingBehandler: PBehandler? = null,
-
+        shouldUpdateKontorNavn: Boolean = false,
     ) {
         if (shouldUpdateKontorSystem(behandlerKontor, existingBehandlerKontor)) {
             updateBehandlerKontorSystem(behandlerKontor.partnerId, behandlerKontor)
         }
         if (shouldUpdateKontorAdresse(behandlerKontor, existingBehandlerKontor)) {
             updateBehandlerKontorAddress(behandlerKontor.partnerId, behandlerKontor)
+        }
+        if (shouldUpdateKontorNavn && kontorNavnChanged(behandlerKontor, existingBehandlerKontor)) {
+            updateBehandlerKontorNavn(behandlerKontor.partnerId, behandlerKontor)
         }
         if (
             behandlerKontor.herId != null &&
@@ -459,6 +467,13 @@ class BehandlerService(
         existingBehandlerKontor: PBehandlerKontor,
     ): Boolean =
         behandlerKontor.harKomplettAdresse() && behandlerKontor.mottatt.isAfter(existingBehandlerKontor.mottatt)
+
+    private fun kontorNavnChanged(
+        behandlerKontor: BehandlerKontor,
+        existingBehandlerKontor: PBehandlerKontor,
+    ) = !behandlerKontor.navn.isNullOrBlank() &&
+        behandlerKontor.navn != existingBehandlerKontor.navn &&
+        behandlerKontor.mottatt.isAfter(existingBehandlerKontor.mottatt)
 
     private fun addBehandlerToArbeidstaker(
         arbeidstaker: Arbeidstaker,

--- a/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/BehandlerService.kt
@@ -438,6 +438,7 @@ class BehandlerService(
             updateBehandlerKontorAddress(behandlerKontor.partnerId, behandlerKontor)
         }
         if (shouldUpdateKontorNavn && kontorNavnChanged(behandlerKontor, existingBehandlerKontor)) {
+            log.info("Oppdaterer kontornavn for partnerId ${behandlerKontor.partnerId}: ${existingBehandlerKontor.navn} -> ${behandlerKontor.navn}")
             updateBehandlerKontorNavn(behandlerKontor.partnerId, behandlerKontor)
         }
         if (

--- a/src/main/kotlin/no/nav/syfo/behandler/database/BehandlerKontorQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/database/BehandlerKontorQuery.kt
@@ -148,16 +148,17 @@ fun Connection.updateBehandlerKontorAddress(partnerId: PartnerId, kontor: Behand
 
 const val queryUpdateBehandlerKontorNavn =
     """
-        UPDATE BEHANDLER_KONTOR SET navn=?,mottatt=?,updated_at=? WHERE partner_id=?
+        UPDATE BEHANDLER_KONTOR SET navn=?,orgnummer=COALESCE(?, orgnummer),mottatt=?,updated_at=? WHERE partner_id=?
     """
 
 fun Connection.updateBehandlerKontorNavn(partnerId: PartnerId, kontor: BehandlerKontor) {
     val rowCount = prepareStatement(queryUpdateBehandlerKontorNavn)
         .use {
             it.setString(1, kontor.navn)
-            it.setObject(2, kontor.mottatt)
-            it.setObject(3, OffsetDateTime.now())
-            it.setString(4, partnerId.toString())
+            it.setString(2, kontor.orgnummer?.value)
+            it.setObject(3, kontor.mottatt)
+            it.setObject(4, OffsetDateTime.now())
+            it.setString(5, partnerId.toString())
             it.executeUpdate()
         }
     if (rowCount != 1) {

--- a/src/main/kotlin/no/nav/syfo/behandler/database/BehandlerKontorQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/database/BehandlerKontorQuery.kt
@@ -146,6 +146,25 @@ fun Connection.updateBehandlerKontorAddress(partnerId: PartnerId, kontor: Behand
     }
 }
 
+const val queryUpdateBehandlerKontorNavn =
+    """
+        UPDATE BEHANDLER_KONTOR SET navn=?,mottatt=?,updated_at=? WHERE partner_id=?
+    """
+
+fun Connection.updateBehandlerKontorNavn(partnerId: PartnerId, kontor: BehandlerKontor) {
+    val rowCount = prepareStatement(queryUpdateBehandlerKontorNavn)
+        .use {
+            it.setString(1, kontor.navn)
+            it.setObject(2, kontor.mottatt)
+            it.setObject(3, OffsetDateTime.now())
+            it.setString(4, partnerId.toString())
+            it.executeUpdate()
+        }
+    if (rowCount != 1) {
+        throw RuntimeException("No row in BEHANDLER_KONTOR with partner_id $partnerId")
+    }
+}
+
 const val queryGetBehandlerKontorById =
     """
         SELECT * FROM BEHANDLER_KONTOR WHERE id = ?

--- a/src/main/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjob.kt
@@ -57,7 +57,10 @@ class VerifyBehandlereForKontorCronjob(
                         log.info("VerifyBehandlereForKontorCronjob: Disable dialogmelding for kontor siden inaktiv i Adresseregisteret: herId ${behandlerKontor.herId} partnerId ${behandlerKontor.partnerId}")
                         behandlerService.disableDialogmeldingerForKontor(behandlerKontor)
                     } else {
-                        behandlerService.updateBehandlerKontorSystemAndAdresse(behandlerKontorFraAdresseregisteret.toBehandlerKontor(behandlerKontor.partnerId))
+                        behandlerService.updateBehandlerKontorSystemAndAdresseAndNavn(
+                            behandlerKontor = behandlerKontorFraAdresseregisteret.toBehandlerKontor(behandlerKontor.partnerId),
+                            shouldUpdateKontorNavn = true,
+                        )
 
                         val (aktiveBehandlereForKontor, inaktiveBehandlereForKontor) = getBehandlereFraAdresseregisteret(behandlerKontorFraAdresseregisteret)
 

--- a/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobTest.kt
@@ -128,6 +128,16 @@ class VerifyBehandlereForKontorCronjobTest {
     }
 
     @Test
+    fun `Cronjob oppdaterer navn om det er endret`() = runTest {
+        val kontorId = createKontor(HERID_KONTOR_OK)
+        val kontorBefore = database.getBehandlerKontorById(kontorId)
+        assertEquals(kontorBefore.navn, "Legekontoret")
+        cronJob.verifyBehandlereForKontorJob()
+        val kontorAfter = database.getBehandlerKontorById(kontorId)
+        assertEquals(kontorAfter.navn, "Fastlegens kontor")
+    }
+
+    @Test
     fun `Cronjob setter hprId på behandlere som mangler det`() = runTest {
         val kontorId = createKontor(HERID_KONTOR_OK)
         val pBehandler = createBehandler(

--- a/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobTest.kt
@@ -132,9 +132,11 @@ class VerifyBehandlereForKontorCronjobTest {
         val kontorId = createKontor(HERID_KONTOR_OK)
         val kontorBefore = database.getBehandlerKontorById(kontorId)
         assertEquals(kontorBefore.navn, "Legekontoret")
+        assertNull(kontorBefore.orgnummer)
         cronJob.verifyBehandlereForKontorJob()
         val kontorAfter = database.getBehandlerKontorById(kontorId)
         assertEquals(kontorAfter.navn, "Fastlegens kontor")
+        assertEquals(kontorAfter.orgnummer, "987654321")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/BehandlerKontorResponseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/BehandlerKontorResponseGenerator.kt
@@ -23,7 +23,7 @@ fun generateBehandlerKontorResponse(
     postadresse = generateBehandlerKontorAdresse(),
     telefon = "",
     epost = "",
-    orgnummer = null,
+    orgnummer = UserConstants.ORGNR_KONTOR_OK,
     behandlere = mutableListOf(
         generateBehandlerFraAdresseregisteret(HPRID_INACTIVE),
         if (kontorHerId == UserConstants.HERID_PSYKOLOG_KONTOR_OK) {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lar cronjob'en som synkroniserer behandlerkontor fra Adresseregisteret til NHN også oppdatere kontornavn. Det har kommet noen jira-saker på at behandlere ser ut til å høre til feil kontor, men det er bare selve navnet på kontoret som har endret seg.

Feks: https://jira.adeo.no/browse/FAGSYSTEM-426268