### PR TITLE
Is 3758 write access

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
@@ -10,6 +10,7 @@ suspend fun RoutingContext.validateVeilederAccess(
     action: String,
     personidentToAccess: Personident,
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
+    requiresWriteAccess: Boolean = false,
     requestBlock: suspend () -> Unit,
 ) {
     val callId = getCallId()
@@ -17,11 +18,19 @@ suspend fun RoutingContext.validateVeilederAccess(
     val token = getBearerHeader()
         ?: throw IllegalArgumentException("Failed to complete the following action: $action. No Authorization header supplied")
 
-    val hasVeilederAccess = veilederTilgangskontrollClient.hasAccess(
-        callId = callId,
-        personident = personidentToAccess,
-        token = token,
-    )
+    val hasVeilederAccess = if (requiresWriteAccess) {
+        veilederTilgangskontrollClient.hasWriteAccess(
+            callId = callId,
+            personident = personidentToAccess,
+            token = token,
+        )
+    } else {
+        veilederTilgangskontrollClient.hasAccess(
+            callId = callId,
+            personident = personidentToAccess,
+            token = token,
+        )
+    }
     if (hasVeilederAccess) {
         requestBlock()
     } else {

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/Tilgang.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/Tilgang.kt
@@ -2,4 +2,5 @@ package no.nav.syfo.client.veiledertilgang
 
 data class Tilgang(
     val erGodkjent: Boolean,
+    val fullTilgang: Boolean = false,
 )

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -4,16 +4,13 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import io.ktor.http.*
-import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.httpClientDefault
 import no.nav.syfo.domain.Personident
 import no.nav.syfo.util.NAV_CALL_ID_HEADER
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.bearerHeader
-import no.nav.syfo.util.callIdArgument
 import org.slf4j.LoggerFactory
 
 class VeilederTilgangskontrollClient(
@@ -24,11 +21,15 @@ class VeilederTilgangskontrollClient(
 ) {
     private val tilgangskontrollPersonUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_PERSON_PATH"
 
-    suspend fun hasAccess(
-        callId: String,
-        personident: Personident,
-        token: String,
-    ): Boolean {
+    suspend fun hasAccess(callId: String, personident: Personident, token: String): Boolean =
+        getTilgang(callId, personident, token)?.erGodkjent ?: false
+
+    suspend fun hasWriteAccess(callId: String, personident: Personident, token: String): Boolean =
+        getTilgang(callId, personident, token)?.let {
+            it.erGodkjent && it.fullTilgang
+        } ?: false
+
+    private suspend fun getTilgang(callId: String, personident: Personident, token: String): Tilgang? {
         val onBehalfOfToken = azureAdClient.getOnBehalfOfToken(
             scopeClientId = istilgangskontrollClientId,
             token = token,
@@ -42,30 +43,20 @@ class VeilederTilgangskontrollClient(
                 accept(ContentType.Application.Json)
             }
             COUNT_CALL_TILGANGSKONTROLL_PERSON_SUCCESS.increment()
-            response.body<Tilgang>().erGodkjent
+            response.body<Tilgang>()
         } catch (e: ClientRequestException) {
             if (e.response.status == HttpStatusCode.Forbidden) {
                 COUNT_CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN.increment()
             } else {
-                handleUnexpectedResponseException(e.response, callId)
+                log.error("Error while requesting access to person from istilgangskontroll with statuscode: ${e.response.status.value}, callId: $callId")
+                COUNT_CALL_TILGANGSKONTROLL_PERSON_FAIL.increment()
             }
-            false
+            null
         } catch (e: ServerResponseException) {
-            handleUnexpectedResponseException(e.response, callId)
-            false
+            log.error("Error while requesting access to person from istilgangskontroll with statuscode: ${e.response.status.value}, callId: $callId")
+            COUNT_CALL_TILGANGSKONTROLL_PERSON_FAIL.increment()
+            null
         }
-    }
-
-    private fun handleUnexpectedResponseException(
-        response: HttpResponse,
-        callId: String,
-    ) {
-        log.error(
-            "Error while requesting access to person from istilgangskontroll with {}, {}",
-            StructuredArguments.keyValue("statusCode", response.status.value.toString()),
-            callIdArgument(callId)
-        )
-        COUNT_CALL_TILGANGSKONTROLL_PERSON_FAIL.increment()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.util
 
+import com.auth0.jwt.JWT
 import io.ktor.server.application.*
 import io.ktor.http.*
 import io.ktor.server.routing.*
@@ -8,6 +9,10 @@ import net.logstash.logback.argument.StructuredArguments
 
 const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
 const val NAV_PERSONIDENT_HEADER = "nav-personident"
+const val JWT_CLAIM_NAVIDENT = "NAVident"
+
+fun getNavIdentFromToken(token: String): String? =
+    runCatching { JWT.decode(token).claims[JWT_CLAIM_NAVIDENT]?.asString() }.getOrNull()
 
 fun RoutingContext.getCallId(): String {
     return this.call.getCallId()

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -1,18 +1,12 @@
 package no.nav.syfo.util
 
-import com.auth0.jwt.JWT
 import io.ktor.server.application.*
 import io.ktor.http.*
 import io.ktor.server.routing.*
-import io.ktor.util.pipeline.*
 import net.logstash.logback.argument.StructuredArguments
 
 const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
 const val NAV_PERSONIDENT_HEADER = "nav-personident"
-const val JWT_CLAIM_NAVIDENT = "NAVident"
-
-fun getNavIdentFromToken(token: String): String? =
-    runCatching { JWT.decode(token).claims[JWT_CLAIM_NAVIDENT]?.asString() }.getOrNull()
 
 fun RoutingContext.getCallId(): String {
     return this.call.getCallId()

--- a/src/test/kotlin/no/nav/syfo/client/VeilederTilgangskontrollClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/VeilederTilgangskontrollClientTest.kt
@@ -1,0 +1,135 @@
+package no.nav.syfo.client
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.azuread.AzureAdToken
+import no.nav.syfo.client.veiledertilgang.Tilgang
+import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.mocks.respondOk
+import no.nav.syfo.testhelper.testEnvironment
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class VeilederTilgangskontrollClientTest {
+    private val token = "token"
+    private val oboToken = "obo-token"
+    private val callId = "call-id"
+    private val personident = UserConstants.ARBEIDSTAKER_FNR
+    private val azureAdClient = mockk<AzureAdClient>()
+    private val environment = testEnvironment()
+
+    @BeforeEach
+    fun setup() {
+        coEvery {
+            azureAdClient.getOnBehalfOfToken(any(), any())
+        } returns AzureAdToken(
+            accessToken = oboToken,
+            expires = LocalDateTime.now().plusHours(1),
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `hasAccess and hasWriteAccess returns false when tilgang is not approved`() {
+        val client = createMockClientForResponse(Tilgang(erGodkjent = false, fullTilgang = true))
+
+        runBlocking {
+            assertFalse(client.hasAccess(callId, personident, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess and hasWriteAccess returns true when approved and user has fullTilgang`() {
+        val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = true))
+
+        runBlocking {
+            assertTrue(client.hasAccess(callId, personident, token))
+            assertTrue(client.hasWriteAccess(callId, personident, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess returns true and hasWriteAccess returns false when approved but user does not have fullTilgang`() {
+        val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = false))
+
+        runBlocking {
+            assertTrue(client.hasAccess(callId, personident, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess and hasWriteAccess returns false on unexpected response`() {
+        val client = createMockClientForResponse(status = HttpStatusCode.InternalServerError)
+
+        runBlocking {
+            assertFalse(client.hasAccess(callId, personident, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess and hasWriteAccess returns false when access is Forbidden`() {
+        val client = createMockClientForResponse(status = HttpStatusCode.Forbidden)
+
+        runBlocking {
+            assertFalse(client.hasAccess(callId, personident, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess throws when OBO token request fails`() {
+        coEvery {
+            azureAdClient.getOnBehalfOfToken(any(), any())
+        } returns null
+
+        val client = createMockClientForResponse()
+
+        assertThrows(RuntimeException::class.java) {
+            runBlocking {
+                client.hasAccess(callId, personident, token)
+            }
+        }
+    }
+
+    private fun createMockClientForResponse(
+        tilgang: Tilgang = Tilgang(erGodkjent = true),
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ): VeilederTilgangskontrollClient {
+        val httpClient = HttpClient(MockEngine) {
+            commonConfig()
+            engine {
+                addHandler {
+                    if (status == HttpStatusCode.OK) {
+                        respondOk(tilgang)
+                    } else {
+                        respond("error", status, headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString()))
+                    }
+                }
+            }
+        }
+
+        return VeilederTilgangskontrollClient(
+            azureAdClient = azureAdClient,
+            istilgangskontrollClientId = environment.istilgangskontrollClientId,
+            tilgangskontrollBaseUrl = environment.istilgangskontrollUrl,
+            httpClient = httpClient,
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -44,6 +44,7 @@ object UserConstants {
     const val ORGNR_KONTOR_OK = "987654321"
 
     const val VEILEDER_IDENT = "Z999999"
+    const val VEILEDER_IDENT_NO_WRITE_ACCESS = "Z888888"
 
     val FASTLEGE_FNR = Personident("12125678911")
     val FASTLEGE_FNR_SUSPENDERT = Personident("12125678912")

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/AzureADMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/AzureADMock.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.testhelper.mocks
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
 import no.nav.syfo.application.api.authentication.WellKnown
 import no.nav.syfo.client.azuread.AzureAdTokenResponse
 import java.nio.file.Paths
@@ -17,10 +18,13 @@ fun wellKnownInternalAzureAD(): WellKnown {
     )
 }
 
-fun MockRequestHandleScope.azureAdMockResponse(): HttpResponseData = respondOk(
-    AzureAdTokenResponse(
-        access_token = "token",
-        expires_in = 3600,
-        token_type = "type",
+fun MockRequestHandleScope.azureAdMockResponse(request: HttpRequestData): HttpResponseData {
+    val assertionToken = (request.body as? FormDataContent)?.formData?.get("assertion")
+    return respondOk(
+        AzureAdTokenResponse(
+            access_token = assertionToken ?: "token",
+            expires_in = 3600,
+            token_type = "type",
+        )
     )
-)
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/MockHttpClient.kt
@@ -11,7 +11,7 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
         addHandler { request ->
             val requestUrl = request.url.encodedPath
             when {
-                requestUrl == "/${environment.azureOpenidConfigTokenEndpoint}" -> azureAdMockResponse()
+                requestUrl == "/${environment.azureOpenidConfigTokenEndpoint}" -> azureAdMockResponse(request)
                 requestUrl.startsWith("/${environment.istilgangskontrollUrl}") -> tilgangskontrollResponse(
                     request
                 )

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfoTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfoTilgangskontrollMock.kt
@@ -3,16 +3,16 @@ package no.nav.syfo.testhelper.mocks
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import no.nav.syfo.application.api.authentication.getNAVIdentFromToken
 import no.nav.syfo.client.veiledertilgang.Tilgang
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_NO_WRITE_ACCESS
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
-import no.nav.syfo.util.getNavIdentFromToken
 
 private fun HttpRequestData.navIdent(): String? =
     headers[HttpHeaders.Authorization]
         ?.removePrefix("Bearer ")
-        ?.let { getNavIdentFromToken(it) }
+        ?.let { getNAVIdentFromToken(it) }
 
 fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequestData): HttpResponseData {
     val erGodkjent = request.headers[NAV_PERSONIDENT_HEADER] != ARBEIDSTAKER_VEILEDER_NO_ACCESS.value

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfoTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/SyfoTilgangskontrollMock.kt
@@ -2,13 +2,20 @@ package no.nav.syfo.testhelper.mocks
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 import no.nav.syfo.client.veiledertilgang.Tilgang
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
+import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_NO_WRITE_ACCESS
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.util.getNavIdentFromToken
+
+private fun HttpRequestData.navIdent(): String? =
+    headers[HttpHeaders.Authorization]
+        ?.removePrefix("Bearer ")
+        ?.let { getNavIdentFromToken(it) }
 
 fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequestData): HttpResponseData {
-    return when (request.headers[NAV_PERSONIDENT_HEADER]) {
-        ARBEIDSTAKER_VEILEDER_NO_ACCESS.value -> respondOk(Tilgang(erGodkjent = false))
-        else -> respondOk(Tilgang(erGodkjent = true))
-    }
+    val erGodkjent = request.headers[NAV_PERSONIDENT_HEADER] != ARBEIDSTAKER_VEILEDER_NO_ACCESS.value
+    val fullTilgang = request.navIdent() != VEILEDER_IDENT_NO_WRITE_ACCESS
+    return respondOk(Tilgang(erGodkjent = erGodkjent, fullTilgang = fullTilgang))
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Mulighet til å sjekke om veileder har skrivetilgang. Her er det ingen endepunkter, slik jeg har forstått det, som krever skrivetilgang. Fikk Copilot til å legge til støtte for det likevel. Vi får vurdere om det er verdt å merge inn eller ikke 😄

Det er bare et endepunkt i appen som tar i bruk `validateVeilederAccess`, og det er `GET /api/v1/behandler/personident`.
@geir-waagboe nevnte at Kelvin muligens bruker dette endepunktet. Her må det kanskje gjøres en tilgangsjekk som kun forholder seg til populasjon?