### PR TITLE
IS-3882: Oppdater kontornavn med visningsnavn fra Adresseregisteret

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/fastlege/BehandlerKontorFraAdresseregisteretDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/fastlege/BehandlerKontorFraAdresseregisteretDTO.kt
@@ -9,6 +9,7 @@ data class BehandlerKontorFraAdresseregisteretDTO(
     val aktiv: Boolean,
     val herId: Int,
     val navn: String,
+    val visningsnavn: String,
     val besoksadresse: Adresse?,
     val postadresse: Adresse?,
     val telefon: String?,
@@ -38,7 +39,7 @@ fun BehandlerKontorFraAdresseregisteretDTO.toBehandlerKontor(partnerId: String) 
     BehandlerKontor(
         partnerId = PartnerId(partnerId.toInt()),
         herId = this.herId,
-        navn = this.navn,
+        navn = this.visningsnavn,
         adresse = this.besoksadresse?.adresse ?: this.postadresse?.adresse,
         postnummer = this.besoksadresse?.postnummer ?: this.postadresse?.postnummer,
         poststed = this.besoksadresse?.poststed ?: this.postadresse?.poststed,

--- a/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/VerifyBehandlereForKontorCronjobTest.kt
@@ -135,7 +135,7 @@ class VerifyBehandlereForKontorCronjobTest {
         assertNull(kontorBefore.orgnummer)
         cronJob.verifyBehandlereForKontorJob()
         val kontorAfter = database.getBehandlerKontorById(kontorId)
-        assertEquals(kontorAfter.navn, "Fastlegens kontor")
+        assertEquals(kontorAfter.navn, "Fastlegens kontor visningsnavn")
         assertEquals(kontorAfter.orgnummer, "987654321")
     }
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/BehandlerKontorResponseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/BehandlerKontorResponseGenerator.kt
@@ -19,7 +19,7 @@ fun generateBehandlerKontorResponse(
     aktiv = aktiv,
     herId = kontorHerId,
     navn = "Fastlegens kontor",
-    visningsnavn = "Fastlegens kontor",
+    visningsnavn = "Fastlegens kontor visningsnavn",
     besoksadresse = null,
     postadresse = generateBehandlerKontorAdresse(),
     telefon = "",

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/BehandlerKontorResponseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/BehandlerKontorResponseGenerator.kt
@@ -19,6 +19,7 @@ fun generateBehandlerKontorResponse(
     aktiv = aktiv,
     herId = kontorHerId,
     navn = "Fastlegens kontor",
+    visningsnavn = "Fastlegens kontor",
     besoksadresse = null,
     postadresse = generateBehandlerKontorAdresse(),
     telefon = "",


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Oppdatering av kontornavn i forrige PR ble ikke helt bra. Så kjører det på nytt der vi bruker visningsnavn fra kontoret i Adresseregisteret i stedet. 

Må merges etter https://github.com/navikt/fastlegerest/pull/226