### PR TITLE
Gi sporhund tilgang til å lese kvitteringer på dialogmeldinger

### DIFF
--- a/.nais/kafka/behandler-dialogmelding-status.yaml
+++ b/.nais/kafka/behandler-dialogmelding-status.yaml
@@ -31,3 +31,6 @@ spec:
     - team: aap
       application: dokumentinnhenting
       access: read
+    - team: tbd
+      application: sporhund
+      access: read


### PR DESCRIPTION
Sporhund er team Sas (sykepenger) sin app for å sende og motta dialogmeldinger

### Hva har blitt lagt til✨🌈

Hva er nytt / hva har blitt fikset?