### PR TITLE
IS-3941: Ta i bruk /suspensjon/soek i LegeSuspensjonClient

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/btsys/LegeSuspensjonClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/btsys/LegeSuspensjonClient.kt
@@ -9,7 +9,6 @@ import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.httpClientDefault
 import no.nav.syfo.domain.Personident
 import no.nav.syfo.util.NAV_CALL_ID_HEADER
-import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.bearerHeader
 import java.io.IOException
 import java.util.*
@@ -28,12 +27,13 @@ class LegeSuspensjonClient(
         val token = azureAdClient.getSystemToken(endpointClientId)
             ?: throw RuntimeException("Failed to sjekk suspensjon: No token was found")
 
-        val httpResponse: HttpResponse = httpClient.get("$endpointUrl/api/v1/suspensjon/status") {
+        val httpResponse: HttpResponse = httpClient.post("$endpointUrl/api/v1/suspensjon/soek") {
             accept(ContentType.Application.Json)
-            header(NAV_PERSONIDENT_HEADER, behandlerPersonident.value)
+            contentType(ContentType.Application.Json)
             header("Nav-Consumer-Id", APPLICATION_NAME)
             header(NAV_CALL_ID_HEADER, UUID.randomUUID().toString())
             header("Authorization", bearerHeader(token.accessToken))
+            setBody(SuspensjonSoekRequest(personident = behandlerPersonident.value))
         }
         if (httpResponse.status != HttpStatusCode.OK) {
             throw IOException("Btsys svarte med uventet kode ${httpResponse.status}")
@@ -41,5 +41,7 @@ class LegeSuspensjonClient(
         return httpResponse.call.response.body()
     }
 }
+
+data class SuspensjonSoekRequest(val personident: String)
 
 data class Suspendert(val suspendert: Boolean)

--- a/src/test/kotlin/no/nav/syfo/testhelper/mocks/BtsysMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mocks/BtsysMock.kt
@@ -3,10 +3,10 @@ package no.nav.syfo.testhelper.mocks
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import no.nav.syfo.client.btsys.Suspendert
+import no.nav.syfo.client.btsys.SuspensjonSoekRequest
 import no.nav.syfo.testhelper.UserConstants
-import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 
-fun MockRequestHandleScope.btsysMockResponse(request: HttpRequestData): HttpResponseData {
-    val personIdentHeader = request.headers.get(NAV_PERSONIDENT_HEADER)
-    return respondOk(Suspendert(UserConstants.FASTLEGE_FNR_SUSPENDERT.value.equals(personIdentHeader)))
+suspend fun MockRequestHandleScope.btsysMockResponse(request: HttpRequestData): HttpResponseData {
+    val requestBody = request.receiveBody<SuspensjonSoekRequest>()
+    return respondOk(Suspendert(UserConstants.FASTLEGE_FNR_SUSPENDERT.value == requestBody.personident))
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

GET /api/v1/suspensjon/status i btsys slettes 1. juli