### PR TITLE
IS-4000: Add dialogmelding_enabled to behandler

### DIFF
--- a/src/main/resources/db/migration/V7_42__activate_kontor.sql
+++ b/src/main/resources/db/migration/V7_42__activate_kontor.sql
@@ -1,0 +1,1 @@
+UPDATE BEHANDLER_KONTOR SET dialogmelding_enabled=now() WHERE partner_id='16667';


### PR DESCRIPTION
Måtte grave meg frem til `partner_id` siden jeg kun fikk HPR i Jira-saken. Hvis dette skjer i fremtiden, kan man finne nummeret med dette queriet:

```
SELECT DISTINCT
    k.partner_id
FROM BEHANDLER b
INNER JOIN BEHANDLER_KONTOR k ON k.id = b.kontor_id
WHERE b.hpr_id = '<HPR>'
  AND b.invalidated IS NULL;
```