### PR TITLE
IS-3931: Bruke innbygger-tilgangskontroll i BehandlerApi

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandler/api/BehandlerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/BehandlerApi.kt
@@ -5,7 +5,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.behandler.BehandlerService
-import no.nav.syfo.behandler.api.access.validateVeilederAccess
+import no.nav.syfo.behandler.api.access.validateVeilederInnbyggerAccess
 import no.nav.syfo.behandler.domain.*
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.domain.Personident
@@ -30,7 +30,7 @@ fun Route.registerBehandlerApi(
                 Personident(personident)
             } ?: throw IllegalArgumentException("No Personident supplied")
 
-            validateVeilederAccess(
+            validateVeilederInnbyggerAccess(
                 action = "Read BehandlerList of Person with Personident",
                 personidentToAccess = personident,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,

--- a/src/main/kotlin/no/nav/syfo/behandler/api/BehandlerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/BehandlerApi.kt
@@ -5,7 +5,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.behandler.BehandlerService
-import no.nav.syfo.behandler.api.access.validateVeilederInnbyggerAccess
+import no.nav.syfo.behandler.api.access.validateVeilederPopulasjonAccess
 import no.nav.syfo.behandler.domain.*
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.domain.Personident
@@ -30,7 +30,7 @@ fun Route.registerBehandlerApi(
                 Personident(personident)
             } ?: throw IllegalArgumentException("No Personident supplied")
 
-            validateVeilederInnbyggerAccess(
+            validateVeilederPopulasjonAccess(
                 action = "Read BehandlerList of Person with Personident",
                 personidentToAccess = personident,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,

--- a/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
@@ -6,31 +6,6 @@ import no.nav.syfo.domain.Personident
 import no.nav.syfo.util.getBearerHeader
 import no.nav.syfo.util.getCallId
 
-suspend fun RoutingContext.validateVeilederAccess(
-    action: String,
-    personidentToAccess: Personident,
-    veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
-    requestBlock: suspend () -> Unit,
-) {
-    val callId = getCallId()
-
-    val token = getBearerHeader()
-        ?: throw IllegalArgumentException("Failed to complete the following action: $action. No Authorization header supplied")
-
-    val hasVeilederAccess = veilederTilgangskontrollClient.hasAccess(
-        callId = callId,
-        personident = personidentToAccess,
-        token = token,
-    )
-    if (hasVeilederAccess) {
-        requestBlock()
-    } else {
-        throw ForbiddenAccessVeilederException(
-            action = action,
-        )
-    }
-}
-
 suspend fun RoutingContext.validateVeilederInnbyggerAccess(
     action: String,
     personidentToAccess: Personident,

--- a/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
@@ -6,7 +6,7 @@ import no.nav.syfo.domain.Personident
 import no.nav.syfo.util.getBearerHeader
 import no.nav.syfo.util.getCallId
 
-suspend fun RoutingContext.validateVeilederInnbyggerAccess(
+suspend fun RoutingContext.validateVeilederPopulasjonAccess(
     action: String,
     personidentToAccess: Personident,
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,

--- a/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
@@ -17,7 +17,7 @@ suspend fun RoutingContext.validateVeilederInnbyggerAccess(
     val token = getBearerHeader()
         ?: throw IllegalArgumentException("Failed to complete the following action: $action. No Authorization header supplied")
 
-    val hasVeilederAccess = veilederTilgangskontrollClient.hasInnbyggerAccess(
+    val hasVeilederAccess = veilederTilgangskontrollClient.hasPopulasjonAccess(
         callId = callId,
         personident = personidentToAccess,
         token = token,

--- a/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/api/access/VeilederAPIAccessPipeline.kt
@@ -31,6 +31,31 @@ suspend fun RoutingContext.validateVeilederAccess(
     }
 }
 
+suspend fun RoutingContext.validateVeilederInnbyggerAccess(
+    action: String,
+    personidentToAccess: Personident,
+    veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
+    requestBlock: suspend () -> Unit,
+) {
+    val callId = getCallId()
+
+    val token = getBearerHeader()
+        ?: throw IllegalArgumentException("Failed to complete the following action: $action. No Authorization header supplied")
+
+    val hasVeilederAccess = veilederTilgangskontrollClient.hasInnbyggerAccess(
+        callId = callId,
+        personident = personidentToAccess,
+        token = token,
+    )
+    if (hasVeilederAccess) {
+        requestBlock()
+    } else {
+        throw ForbiddenAccessVeilederException(
+            action = action,
+        )
+    }
+}
+
 class ForbiddenAccessVeilederException(
     action: String,
     message: String = "Denied NAVIdent access to personident: $action",

--- a/src/main/kotlin/no/nav/syfo/behandler/fastlege/FastlegeClient.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/fastlege/FastlegeClient.kt
@@ -145,7 +145,7 @@ class FastlegeClient(
     }
 
     companion object {
-        const val FASTLEGE_PATH = "/fastlegerest/api/v2/innbygger/fastlege"
+        const val FASTLEGE_PATH = "/fastlegerest/api/v2/populasjon/fastlege"
         const val FASTLEGE_SYSTEM_PATH = "/fastlegerest/api/system/v1/fastlege/aktiv/personident"
         const val FASTLEGEVIKAR_SYSTEM_PATH = "/fastlegerest/api/system/v1/fastlege/vikar/personident"
         const val BEHANDLERE_SYSTEM_PATH = "/fastlegerest/api/system/v1"

--- a/src/main/kotlin/no/nav/syfo/behandler/fastlege/FastlegeClient.kt
+++ b/src/main/kotlin/no/nav/syfo/behandler/fastlege/FastlegeClient.kt
@@ -145,7 +145,7 @@ class FastlegeClient(
     }
 
     companion object {
-        const val FASTLEGE_PATH = "/fastlegerest/api/v2/fastlege"
+        const val FASTLEGE_PATH = "/fastlegerest/api/v2/innbygger/fastlege"
         const val FASTLEGE_SYSTEM_PATH = "/fastlegerest/api/system/v1/fastlege/aktiv/personident"
         const val FASTLEGEVIKAR_SYSTEM_PATH = "/fastlegerest/api/system/v1/fastlege/vikar/personident"
         const val BEHANDLERE_SYSTEM_PATH = "/fastlegerest/api/system/v1"

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -23,6 +23,7 @@ class VeilederTilgangskontrollClient(
     private val httpClient: HttpClient = httpClientDefault(),
 ) {
     private val tilgangskontrollPersonUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_PERSON_PATH"
+    private val tilgangskontrollInnbyggerUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_INNBYGGER_PATH"
 
     suspend fun hasAccess(
         callId: String,
@@ -36,6 +37,38 @@ class VeilederTilgangskontrollClient(
 
         return try {
             val response = httpClient.get(tilgangskontrollPersonUrl) {
+                header(HttpHeaders.Authorization, bearerHeader(onBehalfOfToken))
+                header(NAV_PERSONIDENT_HEADER, personident.value)
+                header(NAV_CALL_ID_HEADER, callId)
+                accept(ContentType.Application.Json)
+            }
+            COUNT_CALL_TILGANGSKONTROLL_PERSON_SUCCESS.increment()
+            response.body<Tilgang>().erGodkjent
+        } catch (e: ClientRequestException) {
+            if (e.response.status == HttpStatusCode.Forbidden) {
+                COUNT_CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN.increment()
+            } else {
+                handleUnexpectedResponseException(e.response, callId)
+            }
+            false
+        } catch (e: ServerResponseException) {
+            handleUnexpectedResponseException(e.response, callId)
+            false
+        }
+    }
+
+    suspend fun hasInnbyggerAccess(
+        callId: String,
+        personident: Personident,
+        token: String,
+    ): Boolean {
+        val onBehalfOfToken = azureAdClient.getOnBehalfOfToken(
+            scopeClientId = istilgangskontrollClientId,
+            token = token,
+        )?.accessToken ?: throw RuntimeException("Failed to request access to innbygger: Failed to get OBO token")
+
+        return try {
+            val response = httpClient.get(tilgangskontrollInnbyggerUrl) {
                 header(HttpHeaders.Authorization, bearerHeader(onBehalfOfToken))
                 header(NAV_PERSONIDENT_HEADER, personident.value)
                 header(NAV_CALL_ID_HEADER, callId)
@@ -72,5 +105,6 @@ class VeilederTilgangskontrollClient(
         private val log = LoggerFactory.getLogger(VeilederTilgangskontrollClient::class.java)
 
         const val TILGANGSKONTROLL_PERSON_PATH = "/api/tilgang/navident/person"
+        const val TILGANGSKONTROLL_INNBYGGER_PATH = "/api/tilgang/navident/innbygger"
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -22,9 +22,9 @@ class VeilederTilgangskontrollClient(
     tilgangskontrollBaseUrl: String,
     private val httpClient: HttpClient = httpClientDefault(),
 ) {
-    private val tilgangskontrollInnbyggerUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_INNBYGGER_PATH"
+    private val tilgangskontrollPopulasjonUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_POPULASJON_PATH"
 
-    suspend fun hasInnbyggerAccess(
+    suspend fun hasPopulasjonAccess(
         callId: String,
         personident: Personident,
         token: String,
@@ -35,7 +35,7 @@ class VeilederTilgangskontrollClient(
         )?.accessToken ?: throw RuntimeException("Failed to request access to innbygger: Failed to get OBO token")
 
         return try {
-            val response = httpClient.get(tilgangskontrollInnbyggerUrl) {
+            val response = httpClient.get(tilgangskontrollPopulasjonUrl) {
                 header(HttpHeaders.Authorization, bearerHeader(onBehalfOfToken))
                 header(NAV_PERSONIDENT_HEADER, personident.value)
                 header(NAV_CALL_ID_HEADER, callId)
@@ -61,7 +61,7 @@ class VeilederTilgangskontrollClient(
         callId: String,
     ) {
         log.error(
-            "Error while requesting access to innbygger from istilgangskontroll with {}, {}",
+            "Error while requesting populasjon access from istilgangskontroll with {}, {}",
             StructuredArguments.keyValue("statusCode", response.status.value.toString()),
             callIdArgument(callId)
         )
@@ -71,6 +71,6 @@ class VeilederTilgangskontrollClient(
     companion object {
         private val log = LoggerFactory.getLogger(VeilederTilgangskontrollClient::class.java)
 
-        const val TILGANGSKONTROLL_INNBYGGER_PATH = "/api/tilgang/navident/innbygger"
+        const val TILGANGSKONTROLL_POPULASJON_PATH = "/api/tilgang/navident/populasjon"
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -32,7 +32,7 @@ class VeilederTilgangskontrollClient(
         val onBehalfOfToken = azureAdClient.getOnBehalfOfToken(
             scopeClientId = istilgangskontrollClientId,
             token = token,
-        )?.accessToken ?: throw RuntimeException("Failed to request access to innbygger: Failed to get OBO token")
+        )?.accessToken ?: throw RuntimeException("Failed to request populasjon access to person: Failed to get OBO token")
 
         return try {
             val response = httpClient.get(tilgangskontrollPopulasjonUrl) {

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -22,40 +22,7 @@ class VeilederTilgangskontrollClient(
     tilgangskontrollBaseUrl: String,
     private val httpClient: HttpClient = httpClientDefault(),
 ) {
-    private val tilgangskontrollPersonUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_PERSON_PATH"
     private val tilgangskontrollInnbyggerUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_INNBYGGER_PATH"
-
-    suspend fun hasAccess(
-        callId: String,
-        personident: Personident,
-        token: String,
-    ): Boolean {
-        val onBehalfOfToken = azureAdClient.getOnBehalfOfToken(
-            scopeClientId = istilgangskontrollClientId,
-            token = token,
-        )?.accessToken ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
-
-        return try {
-            val response = httpClient.get(tilgangskontrollPersonUrl) {
-                header(HttpHeaders.Authorization, bearerHeader(onBehalfOfToken))
-                header(NAV_PERSONIDENT_HEADER, personident.value)
-                header(NAV_CALL_ID_HEADER, callId)
-                accept(ContentType.Application.Json)
-            }
-            COUNT_CALL_TILGANGSKONTROLL_PERSON_SUCCESS.increment()
-            response.body<Tilgang>().erGodkjent
-        } catch (e: ClientRequestException) {
-            if (e.response.status == HttpStatusCode.Forbidden) {
-                COUNT_CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN.increment()
-            } else {
-                handleUnexpectedResponseException(e.response, callId)
-            }
-            false
-        } catch (e: ServerResponseException) {
-            handleUnexpectedResponseException(e.response, callId)
-            false
-        }
-    }
 
     suspend fun hasInnbyggerAccess(
         callId: String,
@@ -94,7 +61,7 @@ class VeilederTilgangskontrollClient(
         callId: String,
     ) {
         log.error(
-            "Error while requesting access to person from istilgangskontroll with {}, {}",
+            "Error while requesting access to innbygger from istilgangskontroll with {}, {}",
             StructuredArguments.keyValue("statusCode", response.status.value.toString()),
             callIdArgument(callId)
         )
@@ -104,7 +71,6 @@ class VeilederTilgangskontrollClient(
     companion object {
         private val log = LoggerFactory.getLogger(VeilederTilgangskontrollClient::class.java)
 
-        const val TILGANGSKONTROLL_PERSON_PATH = "/api/tilgang/navident/person"
         const val TILGANGSKONTROLL_INNBYGGER_PATH = "/api/tilgang/navident/innbygger"
     }
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Tilpasser behandler-api'et og legger til rette for Kelvin og Speil: Bruke tilgangskontroll-api og fastlegerest-api som bare krever tilgang til innbygger (og ikke noen av SYFO-tilgangene). 

Disse to PR'ene er relatert (og må merges i riktig rekkefølge):
https://github.com/navikt/istilgangskontroll/pull/208
https://github.com/navikt/fastlegerest/pull/232

Merges i denne rekkefølgen: istilgangskontroll -> fastlegerest -> isdialogmelding
